### PR TITLE
fix: harden pass for v2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,4 +69,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -20,8 +20,8 @@ jobs:
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
       - name: go-test

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,9 +18,9 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.26.x
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       RELEASE_ID: ${{ steps.create-release.outputs.result }}
     steps:
       - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: create-release
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -39,4 +39,4 @@ jobs:
 
       # This updates the documentation on pkg.go.dev and the latest version available via the Go module proxy
       - name: Pull new module version
-        uses: andrewslotin/go-proxy-pull-action@v1.5.0
+        uses: andrewslotin/go-proxy-pull-action@00af8a5a49c844d6dde0bbbc116b72d8fd7ae97c # v1.5.0

--- a/apollo.go
+++ b/apollo.go
@@ -426,7 +426,10 @@ func (a *Apollo) ConsumeUTxO(utxo common.Utxo, payments ...PaymentI) (*Apollo, e
 	a.preselectedUtxos = append(a.preselectedUtxos, utxo)
 	a.payments = append(a.payments, payments...)
 	if remainder.Coin > 0 || remainder.HasAssets() {
-		remainderPayment := NewPaymentFromValue(a.wallet.Address(), remainder)
+		remainderPayment, err := NewPaymentFromValue(a.wallet.Address(), remainder)
+		if err != nil {
+			return a, fmt.Errorf("failed to build remainder payment: %w", err)
+		}
 		a.payments = append(a.payments, remainderPayment)
 	}
 	return a, nil

--- a/backend/base.go
+++ b/backend/base.go
@@ -1,11 +1,13 @@
 package backend
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math"
 	"strconv"
 	"strings"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
@@ -89,6 +91,34 @@ func (p ProtocolParameters) CoinsPerUtxoByteValue() int64 {
 type AddressAmount struct {
 	Unit     string `json:"unit"`
 	Quantity string `json:"quantity"`
+}
+
+// ParseAssetUnit splits an API asset unit into policy ID and asset name.
+func ParseAssetUnit(unit string) (common.Blake2b224, cbor.ByteString, error) {
+	if len(unit) < common.Blake2b224Size*2 {
+		return common.Blake2b224{}, cbor.ByteString{}, fmt.Errorf("asset unit is too short: %q", unit)
+	}
+	policyHex := unit[:common.Blake2b224Size*2]
+	nameHex := unit[common.Blake2b224Size*2:]
+
+	policyBytes, err := hex.DecodeString(policyHex)
+	if err != nil {
+		return common.Blake2b224{}, cbor.ByteString{}, fmt.Errorf("invalid policy ID hex %q: %w", policyHex, err)
+	}
+	if len(policyBytes) != common.Blake2b224Size {
+		return common.Blake2b224{}, cbor.ByteString{}, fmt.Errorf("invalid policy ID length: expected %d bytes, got %d", common.Blake2b224Size, len(policyBytes))
+	}
+	var policyId common.Blake2b224
+	copy(policyId[:], policyBytes)
+
+	nameBytes, err := hex.DecodeString(nameHex)
+	if err != nil {
+		return common.Blake2b224{}, cbor.ByteString{}, fmt.Errorf("invalid asset name hex %q: %w", nameHex, err)
+	}
+	if len(nameBytes) > 32 {
+		return common.Blake2b224{}, cbor.ByteString{}, fmt.Errorf("invalid asset name length: expected at most 32 bytes, got %d", len(nameBytes))
+	}
+	return policyId, cbor.NewByteString(nameBytes), nil
 }
 
 // ParseRedeemerTag parses a redeemer purpose string to a RedeemerTag.

--- a/backend/base_test.go
+++ b/backend/base_test.go
@@ -1,7 +1,11 @@
 package backend
 
 import (
+	"encoding/hex"
 	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
 func TestCoinsPerUtxoByteValueDefault(t *testing.T) {
@@ -112,5 +116,53 @@ func TestGenesisParametersStruct(t *testing.T) {
 	}
 	if gp.EpochLength != 432000 {
 		t.Errorf("expected 432000, got %d", gp.EpochLength)
+	}
+}
+
+func TestParseAssetUnit(t *testing.T) {
+	policyHex := "00000000000000000000000000000000000000000000000000000001"
+	assetNameHex := hex.EncodeToString([]byte("TOKEN"))
+	policyID, assetName, err := ParseAssetUnit(policyHex + assetNameHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := hex.EncodeToString(policyID.Bytes()); got != policyHex {
+		t.Fatalf("policy ID = %s, want %s", got, policyHex)
+	}
+	if want := cbor.NewByteString([]byte("TOKEN")); assetName != want {
+		t.Fatalf("asset name = %s, want %s", assetName.String(), want.String())
+	}
+}
+
+func TestParseAssetUnitRejectsInvalidInput(t *testing.T) {
+	tests := []string{
+		"abcd",
+		"0000000000000000000000000000000000000000000000000000000z",
+		"00000000000000000000000000000000000000000000000000000001zz",
+		"00000000000000000000000000000000000000000000000000000001" +
+			"000000000000000000000000000000000000000000000000000000000000000000",
+	}
+	for _, unit := range tests {
+		t.Run(unit, func(t *testing.T) {
+			if _, _, err := ParseAssetUnit(unit); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestParseAssetUnitAllowsEmptyAssetName(t *testing.T) {
+	policyHex := "00000000000000000000000000000000000000000000000000000001"
+	policyID, assetName, err := ParseAssetUnit(policyHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var expected common.Blake2b224
+	expected[27] = 1
+	if policyID != expected {
+		t.Fatalf("policy ID = %x, want %x", policyID.Bytes(), expected.Bytes())
+	}
+	if want := cbor.NewByteString(nil); assetName != want {
+		t.Fatalf("asset name = %s, want empty", assetName.String())
 	}
 }

--- a/backend/blockfrost/blockfrost.go
+++ b/backend/blockfrost/blockfrost.go
@@ -21,7 +21,6 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
-	plutigoData "github.com/blinklabs-io/plutigo/data"
 
 	"github.com/Salvionied/apollo/v2/backend"
 )
@@ -40,7 +39,11 @@ type BlockFrostChainContext struct {
 	genesisCacheAt time.Time
 }
 
-const cacheExpiry = 5 * time.Minute
+const (
+	cacheExpiry                   = 5 * time.Minute
+	maxBlockfrostResponseBytes    = 10 * 1024 * 1024
+	maxBlockfrostErrorSnippetSize = 512
+)
 
 // NewBlockFrostChainContext creates a new BlockFrost backend.
 func NewBlockFrostChainContext(baseUrl string, networkId uint8, projectId string) *BlockFrostChainContext {
@@ -77,12 +80,19 @@ func (b *BlockFrostChainContext) request(method, path string, body io.Reader, co
 		return nil, errors.New("blockfrost: nil response")
 	}
 	defer resp.Body.Close()
-	data, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024)) // 10MB limit
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxBlockfrostResponseBytes+1))
 	if err != nil {
 		return nil, err
 	}
+	if len(data) > maxBlockfrostResponseBytes {
+		return nil, fmt.Errorf("blockfrost response body exceeds %d bytes", maxBlockfrostResponseBytes)
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("blockfrost API error %d: %s", resp.StatusCode, string(data))
+		snippet := data
+		if len(snippet) > maxBlockfrostErrorSnippetSize {
+			snippet = snippet[:maxBlockfrostErrorSnippetSize]
+		}
+		return nil, fmt.Errorf("blockfrost API error %d: %s", resp.StatusCode, string(snippet))
 	}
 	return data, nil
 }
@@ -500,6 +510,9 @@ func (raw *bfAddressUTxO) toUtxo(address common.Address) (common.Utxo, error) {
 	if raw.OutputIndex < 0 {
 		return common.Utxo{}, fmt.Errorf("negative output index: %d", raw.OutputIndex)
 	}
+	if raw.OutputIndex > math.MaxUint32 {
+		return common.Utxo{}, fmt.Errorf("output index %d exceeds uint32 range", raw.OutputIndex)
+	}
 	input := shelley.ShelleyTransactionInput{
 		TxId:        txId,
 		OutputIndex: uint32(raw.OutputIndex),
@@ -524,27 +537,18 @@ func (raw *bfAddressUTxO) toUtxo(address common.Address) (common.Utxo, error) {
 			if !ok {
 				return common.Utxo{}, fmt.Errorf("invalid asset quantity %q for unit %s", amt.Quantity, amt.Unit)
 			}
-			policyHex := amt.Unit[:56]
-			nameHex := amt.Unit[56:]
-			policyBytes, err := hex.DecodeString(policyHex)
-			if err != nil {
-				return common.Utxo{}, fmt.Errorf("invalid policy ID hex %q: %w", policyHex, err)
+			if qty.Sign() < 0 {
+				return common.Utxo{}, fmt.Errorf("negative asset quantity %s for unit %s", qty.String(), amt.Unit)
 			}
-			if len(policyBytes) != common.Blake2b224Size {
-				return common.Utxo{}, fmt.Errorf("invalid policy ID length: expected %d bytes, got %d", common.Blake2b224Size, len(policyBytes))
-			}
-			var policyId common.Blake2b224
-			copy(policyId[:], policyBytes)
-
-			nameBytes, err := hex.DecodeString(nameHex)
+			policyId, assetName, err := backend.ParseAssetUnit(amt.Unit)
 			if err != nil {
-				return common.Utxo{}, fmt.Errorf("invalid asset name hex %q: %w", nameHex, err)
+				return common.Utxo{}, fmt.Errorf("invalid asset unit %q: %w", amt.Unit, err)
 			}
 
 			if _, ok := assetData[policyId]; !ok {
 				assetData[policyId] = make(map[cbor.ByteString]*big.Int)
 			}
-			assetData[policyId][cbor.NewByteString(nameBytes)] = qty
+			assetData[policyId][assetName] = qty
 		} else {
 			return common.Utxo{}, fmt.Errorf("unrecognized unit format %q: expected \"lovelace\" or hex string >= 56 chars (policy_id + asset_name)", amt.Unit)
 		}
@@ -602,13 +606,9 @@ func (b *BlockFrostChainContext) hydrateUtxo(raw bfAddressUTxO, address common.A
 		return common.Utxo{}, fmt.Errorf("unexpected UTxO output type: %T", utxo.Output)
 	}
 	if len(raw.InlineDatum) > 0 && string(raw.InlineDatum) != "null" {
-		datum, err := datumFromBlockfrostJSON(raw.InlineDatum)
+		datumOpt, err := inlineDatumOptionFromBlockfrost(raw.InlineDatum)
 		if err != nil {
 			return common.Utxo{}, fmt.Errorf("failed to decode inline datum: %w", err)
-		}
-		datumOpt, err := inlineDatumOption(datum)
-		if err != nil {
-			return common.Utxo{}, fmt.Errorf("failed to encode inline datum option: %w", err)
 		}
 		output.DatumOption = datumOpt
 	}
@@ -622,32 +622,27 @@ func (b *BlockFrostChainContext) hydrateUtxo(raw bfAddressUTxO, address common.A
 	return utxo, nil
 }
 
-func datumFromBlockfrostJSON(raw json.RawMessage) (*common.Datum, error) {
-	pd, err := plutigoData.DecodeJSON(raw)
-	if err != nil {
-		return nil, err
+// inlineDatumOptionFromBlockfrost builds an inline datum option from BlockFrost's
+// inline_datum field, which is a CBOR-encoded datum serialized as a hex string.
+// The original CBOR bytes are preserved exactly (no JSON decode/re-encode
+// round-trip) so the datum hash is not altered by a non-canonical re-encoding.
+func inlineDatumOptionFromBlockfrost(raw json.RawMessage) (*babbage.BabbageTransactionOutputDatumOption, error) {
+	var datumCborHex string
+	if err := json.Unmarshal(raw, &datumCborHex); err != nil {
+		return nil, fmt.Errorf("inline datum must be a CBOR hex string: %w", err)
 	}
-	datum := &common.Datum{Data: pd}
-	cborBytes, err := plutigoData.Encode(pd)
+	datumBytes, err := hex.DecodeString(datumCborHex)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid inline datum CBOR hex %q: %w", datumCborHex, err)
 	}
-	datum.SetCbor(cborBytes)
-	return datum, nil
-}
-
-func inlineDatumOption(datum *common.Datum) (*babbage.BabbageTransactionOutputDatumOption, error) {
-	datumBytes, err := cbor.Encode(datum)
-	if err != nil {
-		return nil, err
-	}
+	// Inline datum option: [1, #6.24(datum_cbor)]
 	cborBytes, err := cbor.Encode([]any{1, cbor.Tag{Number: 24, Content: datumBytes}})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to encode inline datum option: %w", err)
 	}
 	var opt babbage.BabbageTransactionOutputDatumOption
 	if err := opt.UnmarshalCBOR(cborBytes); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal inline datum option: %w", err)
 	}
 	return &opt, nil
 }

--- a/backend/blockfrost/blockfrost_test.go
+++ b/backend/blockfrost/blockfrost_test.go
@@ -1,8 +1,10 @@
 package blockfrost
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -40,12 +42,15 @@ func TestHydrateUtxoResolvesInlineDatumAndReferenceScript(t *testing.T) {
 
 	addr := testAddress(t)
 	ctx := NewBlockFrostChainContext(server.URL, 0, "")
+	// BlockFrost returns inline_datum as a CBOR-encoded hex string.
+	// 0x182a is the CBOR encoding of the integer 42.
+	wantDatumCbor := []byte{0x18, 0x2a}
 	raw := bfAddressUTxO{
 		TxHash:              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		OutputIndex:         0,
 		Address:             addr.String(),
 		Amount:              []bfAddressAmount{{Unit: "lovelace", Quantity: "1000000"}},
-		InlineDatum:         json.RawMessage(`{"int":42}`),
+		InlineDatum:         json.RawMessage(`"182a"`),
 		ReferenceScriptHash: scriptHashHex,
 	}
 
@@ -60,11 +65,60 @@ func TestHydrateUtxoResolvesInlineDatumAndReferenceScript(t *testing.T) {
 	if output.Datum() == nil {
 		t.Fatal("expected inline datum to be populated")
 	}
+	// The exact on-chain CBOR bytes must be preserved so the datum hash is unchanged.
+	if got := output.Datum().Cbor(); !bytes.Equal(got, wantDatumCbor) {
+		t.Fatalf("inline datum CBOR = %x, want %x", got, wantDatumCbor)
+	}
 	scriptRef := output.ScriptRef()
 	if scriptRef == nil {
 		t.Fatal("expected reference script to be populated")
 	}
 	if _, ok := scriptRef.(common.PlutusV2Script); !ok {
 		t.Fatalf("expected PlutusV2 reference script, got %T", scriptRef)
+	}
+}
+
+func TestAddressUTxOToUtxoRejectsInvalidAssetUnit(t *testing.T) {
+	addr := testAddress(t)
+	raw := bfAddressUTxO{
+		TxHash:      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		OutputIndex: 0,
+		Address:     addr.String(),
+		Amount: []bfAddressAmount{
+			{Unit: "lovelace", Quantity: "1000000"},
+			{Unit: "abcd", Quantity: "1"},
+		},
+	}
+	if _, err := raw.toUtxo(addr); err == nil {
+		t.Fatal("expected invalid asset unit error")
+	}
+}
+
+func TestAddressUTxOToUtxoRejectsNegativeAssetQuantity(t *testing.T) {
+	addr := testAddress(t)
+	raw := bfAddressUTxO{
+		TxHash:      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		OutputIndex: 0,
+		Address:     addr.String(),
+		Amount: []bfAddressAmount{
+			{Unit: "lovelace", Quantity: "1000000"},
+			{Unit: "00000000000000000000000000000000000000000000000000000001", Quantity: "-1"},
+		},
+	}
+	if _, err := raw.toUtxo(addr); err == nil {
+		t.Fatal("expected negative asset quantity error")
+	}
+}
+
+func TestAddressUTxOToUtxoRejectsOutputIndexOverflow(t *testing.T) {
+	addr := testAddress(t)
+	raw := bfAddressUTxO{
+		TxHash:      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		OutputIndex: int(math.MaxUint32) + 1,
+		Address:     addr.String(),
+		Amount:      []bfAddressAmount{{Unit: "lovelace", Quantity: "1000000"}},
+	}
+	if _, err := raw.toUtxo(addr); err == nil {
+		t.Fatal("expected output index overflow error")
 	}
 }

--- a/backend/maestro/maestro.go
+++ b/backend/maestro/maestro.go
@@ -281,6 +281,9 @@ func maestroUtxoToCommon(raw models.Utxo, address common.Address) (common.Utxo, 
 	if raw.Index < 0 {
 		return common.Utxo{}, fmt.Errorf("negative output index: %d", raw.Index)
 	}
+	if raw.Index > math.MaxUint32 {
+		return common.Utxo{}, fmt.Errorf("output index %d exceeds uint32 range", raw.Index)
+	}
 	input := shelley.ShelleyTransactionInput{
 		TxId:        txId,
 		OutputIndex: uint32(raw.Index),
@@ -295,31 +298,19 @@ func maestroUtxoToCommon(raw models.Utxo, address common.Address) (common.Utxo, 
 				return common.Utxo{}, fmt.Errorf("negative lovelace amount: %d", asset.Amount)
 			}
 			lovelace = uint64(asset.Amount) //nolint:gosec // validated non-negative above
-		} else if len(asset.Unit) >= 56 {
-			policyHex := asset.Unit[:56]
-			nameHex := asset.Unit[56:]
-			policyBytes, err := hex.DecodeString(policyHex)
-			if err != nil {
-				return common.Utxo{}, fmt.Errorf("invalid policy ID hex %q: %w", policyHex, err)
-			}
-			if len(policyBytes) != common.Blake2b224Size {
-				return common.Utxo{}, fmt.Errorf("invalid policy ID length: expected %d bytes, got %d", common.Blake2b224Size, len(policyBytes))
-			}
-			var policyId common.Blake2b224
-			copy(policyId[:], policyBytes)
-
-			nameBytes, err := hex.DecodeString(nameHex)
-			if err != nil {
-				return common.Utxo{}, fmt.Errorf("invalid asset name hex %q: %w", nameHex, err)
-			}
+		} else {
 			if asset.Amount < 0 {
 				return common.Utxo{}, fmt.Errorf("negative asset amount %d for unit %s", asset.Amount, asset.Unit)
+			}
+			policyId, assetName, err := backend.ParseAssetUnit(asset.Unit)
+			if err != nil {
+				return common.Utxo{}, fmt.Errorf("invalid asset unit %q: %w", asset.Unit, err)
 			}
 
 			if _, ok := assetData[policyId]; !ok {
 				assetData[policyId] = make(map[cbor.ByteString]*big.Int)
 			}
-			assetData[policyId][cbor.NewByteString(nameBytes)] = big.NewInt(asset.Amount)
+			assetData[policyId][assetName] = big.NewInt(asset.Amount)
 		}
 	}
 

--- a/backend/maestro/maestro_test.go
+++ b/backend/maestro/maestro_test.go
@@ -1,0 +1,64 @@
+package maestro
+
+import (
+	"math"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/maestro-org/go-sdk/models"
+)
+
+func testAddress(t *testing.T) common.Address {
+	t.Helper()
+	var raw [57]byte
+	raw[0] = 0x00
+	raw[1] = 0xAA
+	raw[29] = 0xBB
+	addr, err := common.NewAddressFromBytes(raw[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	return addr
+}
+
+func TestMaestroUtxoToCommonRejectsInvalidAssetUnit(t *testing.T) {
+	addr := testAddress(t)
+	raw := models.Utxo{
+		TxHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Index:  0,
+		Assets: []models.Asset{
+			{Unit: "lovelace", Amount: 1000000},
+			{Unit: "abcd", Amount: 1},
+		},
+	}
+	if _, err := maestroUtxoToCommon(raw, addr); err == nil {
+		t.Fatal("expected invalid asset unit error")
+	}
+}
+
+func TestMaestroUtxoToCommonRejectsNegativeAssetQuantity(t *testing.T) {
+	addr := testAddress(t)
+	raw := models.Utxo{
+		TxHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Index:  0,
+		Assets: []models.Asset{
+			{Unit: "lovelace", Amount: 1000000},
+			{Unit: "00000000000000000000000000000000000000000000000000000001", Amount: -1},
+		},
+	}
+	if _, err := maestroUtxoToCommon(raw, addr); err == nil {
+		t.Fatal("expected negative asset quantity error")
+	}
+}
+
+func TestMaestroUtxoToCommonRejectsOutputIndexOverflow(t *testing.T) {
+	addr := testAddress(t)
+	raw := models.Utxo{
+		TxHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Index:  int64(math.MaxUint32) + 1,
+		Assets: []models.Asset{{Unit: "lovelace", Amount: 1000000}},
+	}
+	if _, err := maestroUtxoToCommon(raw, addr); err == nil {
+		t.Fatal("expected output index overflow error")
+	}
+}

--- a/backend/ogmios/ogmios.go
+++ b/backend/ogmios/ogmios.go
@@ -214,22 +214,22 @@ func (o *OgmiosChainContext) ScriptCbor(scriptHash common.Blake2b224) ([]byte, e
 // --- Ogmios response types and conversion ---
 
 type ogmiosProtocolParams struct {
-	MinFeeCoefficient int64           `json:"minFeeCoefficient"`
-	MinFeeConstant    ogmiosLovelace  `json:"minFeeConstant"`
-	MaxBlockBodySize  ogmiosBytes     `json:"maxBlockBodySize"`
-	MaxBlockHeaderSize ogmiosBytes    `json:"maxBlockHeaderSize"`
-	MaxTxSize         ogmiosBytes     `json:"maxTransactionSize"`
-	StakeKeyDeposit   ogmiosLovelace  `json:"stakeCredentialDeposit"`
-	PoolDeposit       ogmiosLovelace  `json:"stakePoolDeposit"`
-	MinPoolCost       ogmiosLovelace  `json:"minStakePoolCost"`
-	CollateralPercent int             `json:"collateralPercentage"`
-	MaxCollateral     int             `json:"maxCollateralInputs"`
-	MaxValSize        ogmiosBytes     `json:"maxValueSize"`
-	ScriptPrices      ogmiosPrices    `json:"scriptExecutionPrices"`
-	MaxTxExUnits      ogmiosExUnits   `json:"maxExecutionUnitsPerTransaction"`
-	MaxBlockExUnits   ogmiosExUnits   `json:"maxExecutionUnitsPerBlock"`
-	MinUtxoDeposit    int64           `json:"minUtxoDepositCoefficient"`
-	CostModels        json.RawMessage `json:"plutusCostModels"`
+	MinFeeCoefficient  int64           `json:"minFeeCoefficient"`
+	MinFeeConstant     ogmiosLovelace  `json:"minFeeConstant"`
+	MaxBlockBodySize   ogmiosBytes     `json:"maxBlockBodySize"`
+	MaxBlockHeaderSize ogmiosBytes     `json:"maxBlockHeaderSize"`
+	MaxTxSize          ogmiosBytes     `json:"maxTransactionSize"`
+	StakeKeyDeposit    ogmiosLovelace  `json:"stakeCredentialDeposit"`
+	PoolDeposit        ogmiosLovelace  `json:"stakePoolDeposit"`
+	MinPoolCost        ogmiosLovelace  `json:"minStakePoolCost"`
+	CollateralPercent  int             `json:"collateralPercentage"`
+	MaxCollateral      int             `json:"maxCollateralInputs"`
+	MaxValSize         ogmiosBytes     `json:"maxValueSize"`
+	ScriptPrices       ogmiosPrices    `json:"scriptExecutionPrices"`
+	MaxTxExUnits       ogmiosExUnits   `json:"maxExecutionUnitsPerTransaction"`
+	MaxBlockExUnits    ogmiosExUnits   `json:"maxExecutionUnitsPerBlock"`
+	MinUtxoDeposit     int64           `json:"minUtxoDepositCoefficient"`
+	CostModels         json.RawMessage `json:"plutusCostModels"`
 }
 
 type ogmiosLovelace struct {
@@ -443,7 +443,11 @@ func sharedValueToUtxo(txId common.Blake2b256, outputIndex uint32, value shared.
 		OutputIndex: outputIndex,
 	}
 
-	lovelace := value.AdaLovelace().Uint64()
+	lovelaceBig := value.AdaLovelace().BigInt()
+	if lovelaceBig.Sign() < 0 || !lovelaceBig.IsUint64() {
+		return common.Utxo{}, fmt.Errorf("invalid lovelace quantity %s", lovelaceBig.String())
+	}
+	lovelace := lovelaceBig.Uint64()
 	assetData := make(map[common.Blake2b224]map[cbor.ByteString]*big.Int)
 
 	for policyIdStr, assets := range value {
@@ -461,6 +465,10 @@ func sharedValueToUtxo(txId common.Blake2b256, outputIndex uint32, value shared.
 		copy(policyId[:], policyBytes)
 
 		for assetName, qty := range assets {
+			qtyBig := qty.BigInt()
+			if qtyBig.Sign() < 0 {
+				return common.Utxo{}, fmt.Errorf("negative asset quantity %s for policy %s asset %s", qtyBig.String(), policyIdStr, assetName)
+			}
 			nameBytes, err := hex.DecodeString(assetName)
 			if err != nil {
 				return common.Utxo{}, fmt.Errorf("invalid asset name hex %q: %w (asset names must be hex-encoded)", assetName, err)
@@ -468,7 +476,7 @@ func sharedValueToUtxo(txId common.Blake2b256, outputIndex uint32, value shared.
 			if _, ok := assetData[policyId]; !ok {
 				assetData[policyId] = make(map[cbor.ByteString]*big.Int)
 			}
-			assetData[policyId][cbor.NewByteString(nameBytes)] = qty.BigInt()
+			assetData[policyId][cbor.NewByteString(nameBytes)] = new(big.Int).Set(qtyBig)
 		}
 	}
 
@@ -614,4 +622,3 @@ func ogmiosScriptToScriptRef(scriptJSON json.RawMessage) (*common.ScriptRef, err
 
 	return &common.ScriptRef{Type: scriptType, Script: commonScript}, nil
 }
-

--- a/backend/ogmios/ogmios_test.go
+++ b/backend/ogmios/ogmios_test.go
@@ -1,0 +1,47 @@
+package ogmios
+
+import (
+	"testing"
+
+	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync/num"
+	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/shared"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+func testAddress(t *testing.T) common.Address {
+	t.Helper()
+	var raw [57]byte
+	raw[0] = 0x00
+	raw[1] = 0xAA
+	raw[29] = 0xBB
+	addr, err := common.NewAddressFromBytes(raw[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	return addr
+}
+
+func TestSharedValueToUtxoRejectsNegativeLovelace(t *testing.T) {
+	value := shared.Value{
+		shared.AdaPolicy: {
+			shared.AdaAsset: num.Int64(-1),
+		},
+	}
+	if _, err := sharedValueToUtxo(common.Blake2b256{}, 0, value, testAddress(t)); err == nil {
+		t.Fatal("expected negative lovelace error")
+	}
+}
+
+func TestSharedValueToUtxoRejectsNegativeAssetQuantity(t *testing.T) {
+	value := shared.Value{
+		shared.AdaPolicy: {
+			shared.AdaAsset: num.Int64(1000000),
+		},
+		"00000000000000000000000000000000000000000000000000000001": {
+			"544f4b454e": num.Int64(-1),
+		},
+	}
+	if _, err := sharedValueToUtxo(common.Blake2b256{}, 0, value, testAddress(t)); err == nil {
+		t.Fatal("expected negative asset quantity error")
+	}
+}

--- a/metadata_json.go
+++ b/metadata_json.go
@@ -16,7 +16,9 @@ const metadataStringMaxBytes = 64
 
 var (
 	maxMetadataInteger = new(big.Int).SetUint64(^uint64(0))
-	minMetadataInteger = new(big.Int).Neg(new(big.Int).Lsh(big.NewInt(1), 64))
+	// The Cardano metadata integer range is [-(2^64-1), 2^64-1]; cardano-api
+	// rejects values below negate(maxBound::Word64), i.e. below -(2^64-1).
+	minMetadataInteger = new(big.Int).Neg(maxMetadataInteger)
 )
 
 // MetadataJSONSchema selects the Cardano transaction metadata JSON mapping.

--- a/metadata_json_test.go
+++ b/metadata_json_test.go
@@ -137,6 +137,23 @@ func TestShelleyMetadataFromJSONNoSchemaErrors(t *testing.T) {
 	}
 }
 
+func TestShelleyMetadataFromJSONIntegerLowerBound(t *testing.T) {
+	// The Cardano transaction metadata integer range is [-(2^64-1), 2^64-1]
+	// (cardano-api validateTxMetadata rejects n < negate(maxBound::Word64)).
+	// -(2^64-1) is the smallest accepted value; -(2^64) must be rejected.
+	t.Run("min accepted", func(t *testing.T) {
+		md, err := ShelleyMetadataFromJSON([]byte(`{"1":-18446744073709551615}`))
+		if err != nil {
+			t.Fatalf("expected -18446744073709551615 to be accepted, got error: %v", err)
+		}
+		requireBigIntString(t, md[1], "-18446744073709551615")
+	})
+	t.Run("below min rejected", func(t *testing.T) {
+		_, err := ShelleyMetadataFromJSON([]byte(`{"1":-18446744073709551616}`))
+		requireExactError(t, err, "metadata[1]: metadata integer -18446744073709551616 is outside the supported range")
+	})
+}
+
 func TestShelleyMetadataFromJSONWithDetailedSchemaSuccess(t *testing.T) {
 	jsonData := []byte(`{
 		"0": {"int": -1},

--- a/models.go
+++ b/models.go
@@ -3,7 +3,6 @@ package apollo
 import (
 	"encoding/hex"
 	"fmt"
-	"math"
 	"math/big"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -130,7 +129,9 @@ func NewPayment(receiver string, lovelace int64, units []Unit) (*Payment, error)
 }
 
 // NewPaymentFromValue creates a Payment from an Address and Value.
-func NewPaymentFromValue(receiver common.Address, value Value) *Payment {
+// It returns an error if a native-asset quantity exceeds the int64 range,
+// rather than silently truncating or saturating it to a wrong value.
+func NewPaymentFromValue(receiver common.Address, value Value) (*Payment, error) {
 	payment := &Payment{
 		Receiver: receiver,
 		Lovelace: int64(value.Coin), //nolint:gosec // ADA supply fits in int64
@@ -139,28 +140,26 @@ func NewPaymentFromValue(receiver common.Address, value Value) *Payment {
 		for _, policyId := range value.Assets.Policies() {
 			for _, assetName := range value.Assets.Assets(policyId) {
 				qty := value.Assets.Asset(policyId, assetName)
-				// Use Int64() which truncates for values > MaxInt64.
-				// This is safe because Cardano native asset quantities fit in int64.
-				q := qty.Int64()
 				if !qty.IsInt64() {
-					// Saturate to MaxInt64 for out-of-range values rather than silently truncating.
-					q = math.MaxInt64
+					return nil, fmt.Errorf("asset quantity %s for policy %s exceeds int64 range", qty.String(), hex.EncodeToString(policyId.Bytes()))
 				}
 				payment.Units = append(payment.Units, Unit{
 					PolicyId: hex.EncodeToString(policyId.Bytes()),
 					Name:     hex.EncodeToString(assetName),
-					Quantity: q,
+					Quantity: qty.Int64(),
 				})
 			}
 		}
 	}
-	return payment
+	return payment, nil
 }
 
 // PaymentFromTxOut creates a Payment from a BabbageTransactionOutput.
-func PaymentFromTxOut(txOut *babbage.BabbageTransactionOutput) *Payment {
+// It returns an error if a native-asset quantity exceeds the int64 range,
+// rather than silently truncating or saturating it to a wrong value.
+func PaymentFromTxOut(txOut *babbage.BabbageTransactionOutput) (*Payment, error) {
 	if txOut == nil {
-		return nil
+		return nil, nil
 	}
 	payment := &Payment{
 		Receiver: txOut.OutputAddress,
@@ -170,14 +169,13 @@ func PaymentFromTxOut(txOut *babbage.BabbageTransactionOutput) *Payment {
 		for _, policyId := range txOut.OutputAmount.Assets.Policies() {
 			for _, assetName := range txOut.OutputAmount.Assets.Assets(policyId) {
 				qty := txOut.OutputAmount.Assets.Asset(policyId, assetName)
-				q := qty.Int64()
 				if !qty.IsInt64() {
-					q = math.MaxInt64
+					return nil, fmt.Errorf("asset quantity %s for policy %s exceeds int64 range", qty.String(), hex.EncodeToString(policyId.Bytes()))
 				}
 				payment.Units = append(payment.Units, Unit{
 					PolicyId: hex.EncodeToString(policyId.Bytes()),
 					Name:     hex.EncodeToString(assetName),
-					Quantity: q,
+					Quantity: qty.Int64(),
 				})
 			}
 		}
@@ -189,7 +187,7 @@ func PaymentFromTxOut(txOut *babbage.BabbageTransactionOutput) *Payment {
 	} else if h := txOut.DatumHash(); h != nil {
 		payment.DatumHash = h.Bytes()
 	}
-	return payment
+	return payment, nil
 }
 
 // ToValue converts a Payment to a Value.

--- a/models_test.go
+++ b/models_test.go
@@ -1,8 +1,25 @@
 package apollo
 
 import (
+	"math/big"
 	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
 )
+
+// overflowAssetValue builds a Value holding a native-asset quantity of 2^64,
+// which exceeds the int64 range used by Unit.Quantity.
+func overflowAssetValue(t *testing.T) Value {
+	t.Helper()
+	var policy common.Blake2b224
+	policy[0] = 0xAB
+	huge := new(big.Int).Lsh(big.NewInt(1), 64) // 2^64, exceeds int64
+	assets := MultiAssetFromMap(map[common.Blake2b224]map[cbor.ByteString]*big.Int{
+		policy: {cbor.NewByteString([]byte("TOK")): huge},
+	})
+	return NewValue(0, assets)
+}
 
 func TestNewUnit(t *testing.T) {
 	u := NewUnit("abc123", "token", 100)
@@ -111,17 +128,38 @@ func TestPaymentToTxOut(t *testing.T) {
 func TestPaymentFromTxOut(t *testing.T) {
 	addr := testAddress(t)
 	output := NewBabbageOutputSimple(addr, 7000000)
-	p := PaymentFromTxOut(&output)
+	p, err := PaymentFromTxOut(&output)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if p.Lovelace != 7000000 {
 		t.Errorf("expected 7000000, got %d", p.Lovelace)
+	}
+}
+
+func TestPaymentFromTxOutRejectsOverflowQuantity(t *testing.T) {
+	addr := testAddress(t)
+	output := NewBabbageOutput(addr, overflowAssetValue(t), nil, nil)
+	if _, err := PaymentFromTxOut(&output); err == nil {
+		t.Fatal("expected error for asset quantity exceeding int64 range")
 	}
 }
 
 func TestNewPaymentFromValue(t *testing.T) {
 	addr := testAddress(t)
 	v := NewSimpleValue(4000000)
-	p := NewPaymentFromValue(addr, v)
+	p, err := NewPaymentFromValue(addr, v)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if p.Lovelace != 4000000 {
 		t.Errorf("expected 4000000, got %d", p.Lovelace)
+	}
+}
+
+func TestNewPaymentFromValueRejectsOverflowQuantity(t *testing.T) {
+	addr := testAddress(t)
+	if _, err := NewPaymentFromValue(addr, overflowAssetValue(t)); err == nil {
+		t.Fatal("expected error for asset quantity exceeding int64 range")
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Security hardening across v2: stricter asset parsing/validation, safer Blockfrost/Ogmios handling, and CI pinned to exact action SHAs. Fixes metadata bounds, prevents quantity overflows in payment builders, and preserves inline datum CBOR so datum hashes stay correct.

- **Bug Fixes**
  - Validate asset units/quantities and output index across `blockfrost`, `maestro`, and `ogmios` backends; reject invalid hex, negative amounts, and uint32 overflows.
  - Preserve inline datum CBOR from Blockfrost (no JSON round-trip) to keep datum hashes stable; improve error messages.
  - Limit Blockfrost responses to 10MB and truncate error snippets; safer HTTP handling.
  - Correct metadata integer lower bound to −(2^64−1); payment builders now error on quantities outside int64.

- **Migration**
  - `NewPaymentFromValue(Address, Value)` now returns `(*Payment, error)`; callers must handle errors for out‑of‑range asset quantities.
  - `PaymentFromTxOut(*babbage.BabbageTransactionOutput)` now returns `(*Payment, error)`; callers must handle possible errors and a nil result when input is nil.

<sup>Written for commit 6e3813c7aedc7ac2f4b08a485c2a9a647d88a79d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/salvionied-apollo/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

