### PR TITLE
refactor: use context throughout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,10 +64,10 @@ golangci-lint run
 
 **ChainContext** (`backend/base.go`):
 
-- `ProtocolParams()` - protocol parameters
-- `Utxos(address)` - query UTxOs
-- `SubmitTx(txCbor)` - submit a transaction
-- `EvaluateTx(txCbor)` - evaluate Plutus scripts
+- `ProtocolParams(ctx)` - protocol parameters
+- `Utxos(ctx, address)` - query UTxOs
+- `SubmitTx(ctx, txCbor)` - submit a transaction
+- `EvaluateTx(ctx, txCbor, additionalUtxos)` - evaluate Plutus scripts
 
 **Wallet** (`wallet.go`):
 

--- a/apollo.go
+++ b/apollo.go
@@ -2,6 +2,7 @@ package apollo
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -1033,6 +1034,12 @@ func (a *Apollo) Clone() *Apollo {
 
 // UtxoFromRef looks up a UTxO by transaction hash and index.
 func (a *Apollo) UtxoFromRef(txHash string, txIndex int) (*common.Utxo, error) {
+	return a.UtxoFromRefContext(context.Background(), txHash, txIndex)
+}
+
+// UtxoFromRefContext looks up a UTxO by transaction hash and index.
+func (a *Apollo) UtxoFromRefContext(ctx context.Context, txHash string, txIndex int) (*common.Utxo, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	hashBytes, err := hex.DecodeString(txHash)
 	if err != nil {
 		return nil, fmt.Errorf("invalid tx hash hex: %w", err)
@@ -1045,7 +1052,7 @@ func (a *Apollo) UtxoFromRef(txHash string, txIndex int) (*common.Utxo, error) {
 	}
 	var hash common.Blake2b256
 	copy(hash[:], hashBytes)
-	return a.Context.UtxoByRef(hash, uint32(txIndex))
+	return a.Context.UtxoByRef(ctx, hash, uint32(txIndex))
 }
 
 // GetUsedUTxOs returns a copy of the used UTxO references.
@@ -1067,6 +1074,12 @@ func (a *Apollo) GetWallet() Wallet {
 
 // Complete performs coin selection, fee estimation, and builds the transaction.
 func (a *Apollo) Complete() (*Apollo, error) {
+	return a.CompleteContext(context.Background())
+}
+
+// CompleteContext performs coin selection, fee estimation, and builds the transaction.
+func (a *Apollo) CompleteContext(ctx context.Context) (*Apollo, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	if a.err != nil {
 		return a, a.err
 	}
@@ -1078,17 +1091,17 @@ func (a *Apollo) Complete() (*Apollo, error) {
 	}
 
 	// Load UTxOs from input addresses if needed (must happen before collateral selection)
-	if err := a.loadUtxos(); err != nil {
+	if err := a.loadUtxos(ctx); err != nil {
 		return a, err
 	}
 
 	// Auto-select collateral if needed (after UTxOs are loaded)
-	if err := a.setCollateral(); err != nil {
+	if err := a.setCollateral(ctx); err != nil {
 		return a, err
 	}
 
 	// Build outputs from payments
-	outputs, err := a.buildOutputs()
+	outputs, err := a.buildOutputs(ctx)
 	if err != nil {
 		return a, err
 	}
@@ -1104,7 +1117,7 @@ func (a *Apollo) Complete() (*Apollo, error) {
 	// a silently wrong deposit produces a value-non-conserving transaction.
 	stakeDeposit := int64(StakeDeposit)
 	if len(a.certificates) > 0 {
-		pp, ppErr := a.Context.ProtocolParams()
+		pp, ppErr := a.Context.ProtocolParams(ctx)
 		if ppErr != nil {
 			return a, fmt.Errorf("failed to get protocol params for certificate deposit: %w", ppErr)
 		}
@@ -1172,7 +1185,7 @@ func (a *Apollo) Complete() (*Apollo, error) {
 	// MaxTxFee covers the size-based fee only; Conway reference-script fees are
 	// charged separately, so reserve the known reference-input / pinned-input
 	// surcharge before coin selection.
-	maxFee, feeErr := a.Context.MaxTxFee()
+	maxFee, feeErr := a.Context.MaxTxFee(ctx)
 	if feeErr != nil {
 		return a, fmt.Errorf("failed to compute max tx fee for coin selection: %w", feeErr)
 	}
@@ -1180,7 +1193,7 @@ func (a *Apollo) Complete() (*Apollo, error) {
 		return a, fmt.Errorf("max tx fee out of range: %d", maxFee)
 	}
 	prelimFee := int64(maxFee)
-	refScriptFeeReserve, err := a.referenceScriptFee(a.preselectedUtxos)
+	refScriptFeeReserve, err := a.referenceScriptFee(ctx, a.preselectedUtxos)
 	if err != nil {
 		return a, fmt.Errorf("failed to compute reference-script fee reserve for coin selection: %w", err)
 	}
@@ -1232,13 +1245,13 @@ func (a *Apollo) Complete() (*Apollo, error) {
 	allInputUtxos = append(allInputUtxos, a.preselectedUtxos...)
 	allInputUtxos = append(allInputUtxos, selectedUtxos...)
 	allInputUtxos = SortInputs(allInputUtxos)
-	if err := a.validateCollateral(); err != nil {
+	if err := a.validateCollateral(ctx); err != nil {
 		return a, err
 	}
 
 	// Automatic ExUnit estimation for script transactions
 	if a.isEstimateRequired && a.estimateExUnits {
-		if err := a.estimateExecutionUnits(allInputUtxos, outputs); err != nil {
+		if err := a.estimateExecutionUnits(ctx, allInputUtxos, outputs); err != nil {
 			return a, fmt.Errorf("ExUnit estimation failed: %w", err)
 		}
 	}
@@ -1256,7 +1269,7 @@ func (a *Apollo) Complete() (*Apollo, error) {
 	if a.forceFee {
 		fee = a.Fee
 	} else {
-		fee, err = a.estimateFee(allInputUtxos, outputs)
+		fee, err = a.estimateFee(ctx, allInputUtxos, outputs)
 		if err != nil {
 			return a, fmt.Errorf("fee estimation failed: %w", err)
 		}
@@ -1329,7 +1342,7 @@ func (a *Apollo) Complete() (*Apollo, error) {
 
 		if changeValue.Coin > 0 || changeValue.HasAssets() {
 			changeOutput := NewBabbageOutput(changeAddr, changeValue, nil, nil)
-			pp, err := a.Context.ProtocolParams()
+			pp, err := a.Context.ProtocolParams(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get protocol params for change output: %w", err)
 			}
@@ -1400,10 +1413,10 @@ func (a *Apollo) Complete() (*Apollo, error) {
 		// the fee accounts for the final collateral total/return footprint in
 		// the body. A collateral_return that only materializes after sizing
 		// would otherwise grow the tx past the frozen estimate.
-		if err := a.finalizeCollateral(fee); err != nil {
+		if err := a.finalizeCollateral(ctx, fee); err != nil {
 			return a, err
 		}
-		newFee, err := a.estimateFee(allInputUtxos, outputs)
+		newFee, err := a.estimateFee(ctx, allInputUtxos, outputs)
 		if err != nil {
 			return a, fmt.Errorf("fee re-estimation failed: %w", err)
 		}
@@ -1434,12 +1447,12 @@ func (a *Apollo) Complete() (*Apollo, error) {
 	// requires total collateral >= ceil(fee * collateralPercent / 100) against
 	// the ACTUAL fee, so a stale preliminary value triggers
 	// InsufficientCollateral. Resize here now that the fee is final.
-	if err := a.finalizeCollateral(fee); err != nil {
+	if err := a.finalizeCollateral(ctx, fee); err != nil {
 		return a, err
 	}
 
 	// Build transaction body
-	body, err := a.buildBody(allInputUtxos, outputs, uint64(fee))
+	body, err := a.buildBody(ctx, allInputUtxos, outputs, uint64(fee))
 	if err != nil {
 		return a, err
 	}
@@ -1518,18 +1531,24 @@ func (a *Apollo) GetTxCbor() ([]byte, error) {
 
 // Submit submits the transaction to the chain.
 func (a *Apollo) Submit() (common.Blake2b256, error) {
+	return a.SubmitContext(context.Background())
+}
+
+// SubmitContext submits the transaction to the chain.
+func (a *Apollo) SubmitContext(ctx context.Context) (common.Blake2b256, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	txCbor, err := a.GetTxCbor()
 	if err != nil {
 		return common.Blake2b256{}, err
 	}
-	return a.Context.SubmitTx(txCbor)
+	return a.Context.SubmitTx(ctx, txCbor)
 }
 
 // --- internal helpers ---
 
-func (a *Apollo) loadUtxos() error {
+func (a *Apollo) loadUtxos(ctx context.Context) error {
 	for _, addr := range a.inputAddresses {
-		utxos, err := a.Context.Utxos(addr)
+		utxos, err := a.Context.Utxos(ctx, addr)
 		if err != nil {
 			return fmt.Errorf("failed to load UTxOs for %s: %w", addr.String(), err)
 		}
@@ -1537,7 +1556,7 @@ func (a *Apollo) loadUtxos() error {
 	}
 	// If no UTxOs loaded and wallet is set, load from wallet address
 	if len(a.utxos) == 0 && len(a.preselectedUtxos) == 0 && a.wallet != nil {
-		utxos, err := a.Context.Utxos(a.wallet.Address())
+		utxos, err := a.Context.Utxos(ctx, a.wallet.Address())
 		if err != nil {
 			return fmt.Errorf("failed to load wallet UTxOs: %w", err)
 		}
@@ -1546,10 +1565,10 @@ func (a *Apollo) loadUtxos() error {
 	return nil
 }
 
-func (a *Apollo) buildOutputs() ([]babbage.BabbageTransactionOutput, error) {
+func (a *Apollo) buildOutputs(ctx context.Context) ([]babbage.BabbageTransactionOutput, error) {
 	outputs := make([]babbage.BabbageTransactionOutput, 0, len(a.payments))
 	for _, payment := range a.payments {
-		if err := payment.EnsureMinUTXO(a.Context); err != nil {
+		if err := payment.EnsureMinUTXO(ctx, a.Context); err != nil {
 			return nil, fmt.Errorf("failed to ensure min UTxO: %w", err)
 		}
 		txOut, err := payment.ToTxOut()
@@ -1644,8 +1663,8 @@ func (a *Apollo) selectCoins(required, currentInput Value) ([]common.Utxo, error
 	return selected, nil
 }
 
-func (a *Apollo) estimateFee(inputs []common.Utxo, outputs []babbage.BabbageTransactionOutput) (int64, error) {
-	pp, err := a.Context.ProtocolParams()
+func (a *Apollo) estimateFee(ctx context.Context, inputs []common.Utxo, outputs []babbage.BabbageTransactionOutput) (int64, error) {
+	pp, err := a.Context.ProtocolParams(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -1657,11 +1676,11 @@ func (a *Apollo) estimateFee(inputs []common.Utxo, outputs []babbage.BabbageTran
 	// producing a fee that is a few hundred lovelace short and a FeeTooSmallUTxO
 	// rejection. Use a placeholder fee whose CBOR width matches (or exceeds) the
 	// final fee so the size — and thus the fee — is not underestimated.
-	placeholderFee, feeErr := a.Context.MaxTxFee()
+	placeholderFee, feeErr := a.Context.MaxTxFee(ctx)
 	if feeErr != nil || placeholderFee == 0 {
 		placeholderFee = 2_000_000
 	}
-	body, err := a.buildBody(inputs, outputs, placeholderFee)
+	body, err := a.buildBody(ctx, inputs, outputs, placeholderFee)
 	if err != nil {
 		return 0, err
 	}
@@ -1722,7 +1741,7 @@ func (a *Apollo) estimateFee(inputs []common.Utxo, outputs []babbage.BabbageTran
 	}
 
 	// Add the Conway tiered reference-script fee.
-	refScriptFee, err := a.referenceScriptFeeWithParams(inputs, pp)
+	refScriptFee, err := a.referenceScriptFeeWithParams(ctx, inputs, pp)
 	if err != nil {
 		return 0, err
 	}
@@ -1734,15 +1753,15 @@ func (a *Apollo) estimateFee(inputs []common.Utxo, outputs []babbage.BabbageTran
 	return fee, nil
 }
 
-func (a *Apollo) referenceScriptFee(inputs []common.Utxo) (int64, error) {
-	refScriptSize, err := a.totalReferenceScriptSize(inputs)
+func (a *Apollo) referenceScriptFee(ctx context.Context, inputs []common.Utxo) (int64, error) {
+	refScriptSize, err := a.totalReferenceScriptSize(ctx, inputs)
 	if err != nil {
 		return 0, err
 	}
 	if refScriptSize == 0 {
 		return 0, nil
 	}
-	pp, err := a.Context.ProtocolParams()
+	pp, err := a.Context.ProtocolParams(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -1756,8 +1775,8 @@ func (a *Apollo) referenceScriptFee(inputs []common.Utxo) (int64, error) {
 // reference inputs regardless of whether the transaction executes scripts, so
 // omitting it produces FeeTooSmallUTxO. The fee is naturally zero when no
 // referenced UTxO carries a script.
-func (a *Apollo) referenceScriptFeeWithParams(inputs []common.Utxo, pp backend.ProtocolParameters) (int64, error) {
-	refScriptSize, err := a.totalReferenceScriptSize(inputs)
+func (a *Apollo) referenceScriptFeeWithParams(ctx context.Context, inputs []common.Utxo, pp backend.ProtocolParameters) (int64, error) {
+	refScriptSize, err := a.totalReferenceScriptSize(ctx, inputs)
 	if err != nil {
 		return 0, err
 	}
@@ -1799,7 +1818,7 @@ func referenceScriptFeeForSize(refScriptSize int, pp backend.ProtocolParameters)
 // resolved against the chain context; an undercounted size silently underprices
 // the fee and gets the tx rejected, so a reference input that fails to resolve
 // is a hard error.
-func (a *Apollo) totalReferenceScriptSize(inputs []common.Utxo) (int, error) {
+func (a *Apollo) totalReferenceScriptSize(ctx context.Context, inputs []common.Utxo) (int, error) {
 	seen := make(map[string]struct{})
 	total := 0
 
@@ -1827,7 +1846,7 @@ func (a *Apollo) totalReferenceScriptSize(inputs []common.Utxo) (int, error) {
 			continue
 		}
 		seen[ref] = struct{}{}
-		utxo, err := a.Context.UtxoByRef(refInput.TxId, refInput.OutputIndex)
+		utxo, err := a.Context.UtxoByRef(ctx, refInput.TxId, refInput.OutputIndex)
 		if err != nil {
 			return 0, fmt.Errorf(
 				"failed to resolve reference input %s for reference-script fee: %w",
@@ -1846,18 +1865,18 @@ func (a *Apollo) totalReferenceScriptSize(inputs []common.Utxo) (int, error) {
 // estimateExecutionUnits builds a preliminary transaction and evaluates it
 // against the chain to get actual execution units for script redeemers.
 // The returned ExUnits include a buffer for safety.
-func (a *Apollo) estimateExecutionUnits(inputs []common.Utxo, outputs []babbage.BabbageTransactionOutput) error {
+func (a *Apollo) estimateExecutionUnits(ctx context.Context, inputs []common.Utxo, outputs []babbage.BabbageTransactionOutput) error {
 	// Build preliminary tx with current (possibly zero) ExUnits. The fee field
 	// is `omitempty`, so a zero fee is dropped from the CBOR and the body has no
 	// fee (key 2). Strict evaluators (Ogmios, and Blockfrost which proxies it)
 	// reject such a body with "field fee with key 2, not decoded". Use a
 	// non-zero placeholder fee so the field is always present; its value does
 	// not affect script evaluation.
-	placeholderFee, feeErr := a.Context.MaxTxFee()
+	placeholderFee, feeErr := a.Context.MaxTxFee(ctx)
 	if feeErr != nil || placeholderFee == 0 {
 		placeholderFee = 2_000_000
 	}
-	body, err := a.buildBody(inputs, outputs, placeholderFee)
+	body, err := a.buildBody(ctx, inputs, outputs, placeholderFee)
 	if err != nil {
 		return fmt.Errorf("failed to build preliminary tx body: %w", err)
 	}
@@ -1893,7 +1912,7 @@ func (a *Apollo) estimateExecutionUnits(inputs []common.Utxo, outputs []babbage.
 		return fmt.Errorf("failed to encode preliminary tx: %w", err)
 	}
 
-	evalResult, err := a.Context.EvaluateTx(txBytes, inputs)
+	evalResult, err := a.Context.EvaluateTx(ctx, txBytes, inputs)
 	if err != nil {
 		return fmt.Errorf("EvaluateTx failed: %w", err)
 	}
@@ -1991,6 +2010,7 @@ func bufferExUnits(v int64, factor float64) int64 {
 }
 
 func (a *Apollo) buildBody(
+	ctx context.Context,
 	inputs []common.Utxo,
 	outputs []babbage.BabbageTransactionOutput,
 	fee uint64,
@@ -2100,12 +2120,12 @@ func (a *Apollo) buildBody(
 
 	// Script data hash
 	if len(a.redeemers) > 0 || len(a.mintRedeemers) > 0 || len(a.stakeRedeemers) > 0 || len(a.datums) > 0 {
-		pp, err := a.Context.ProtocolParams()
+		pp, err := a.Context.ProtocolParams(ctx)
 		if err != nil {
 			return body, err
 		}
 		redeemerMap := a.buildRedeemerMap(inputs)
-		usedCostModels, err := a.usedScriptCostModels(inputs, pp.CostModels)
+		usedCostModels, err := a.usedScriptCostModels(ctx, inputs, pp.CostModels)
 		if err != nil {
 			return body, err
 		}
@@ -2221,6 +2241,7 @@ func (a *Apollo) buildRedeemerMap(inputs []common.Utxo) map[common.RedeemerKey]c
 }
 
 func (a *Apollo) usedScriptCostModels(
+	ctx context.Context,
 	inputs []common.Utxo,
 	available map[string][]int64,
 ) (map[string][]int64, error) {
@@ -2241,7 +2262,7 @@ func (a *Apollo) usedScriptCostModels(
 		addScriptLanguage(used, utxo.Output.ScriptRef())
 	}
 	for _, refInput := range a.referenceInputs {
-		utxo, err := a.Context.UtxoByRef(refInput.TxId, refInput.OutputIndex)
+		utxo, err := a.Context.UtxoByRef(ctx, refInput.TxId, refInput.OutputIndex)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"failed to resolve reference input %s#%d for script data hash: %w",
@@ -2500,7 +2521,7 @@ func (a *Apollo) hasScripts() bool {
 // totalCollateral and collateralReturn are sized here from a preliminary
 // (max-by-size) fee; finalizeCollateral() resizes them once the final fee is
 // known.
-func (a *Apollo) setCollateral() error {
+func (a *Apollo) setCollateral(ctx context.Context) error {
 	if len(a.collaterals) > 0 || !a.hasScripts() {
 		return nil
 	}
@@ -2509,8 +2530,8 @@ func (a *Apollo) setCollateral() error {
 	minCollateral := int64(5_000_000) // conservative fallback
 	if a.collateralAmount > 0 {
 		minCollateral = a.collateralAmount
-	} else if pp, err := a.Context.ProtocolParams(); err == nil {
-		if maxFee, err := a.Context.MaxTxFee(); err == nil && pp.CollateralPercent > 0 &&
+	} else if pp, err := a.Context.ProtocolParams(ctx); err == nil {
+		if maxFee, err := a.Context.MaxTxFee(ctx); err == nil && pp.CollateralPercent > 0 &&
 			maxFee <= math.MaxInt64/uint64(pp.CollateralPercent) {
 			computed := int64(maxFee) * int64(pp.CollateralPercent) / 100 //nolint:gosec // bounded above
 			if computed > 0 {
@@ -2521,7 +2542,7 @@ func (a *Apollo) setCollateral() error {
 
 	candidates := a.utxos
 	if len(candidates) == 0 && a.wallet != nil {
-		loaded, err := a.Context.Utxos(a.wallet.Address())
+		loaded, err := a.Context.Utxos(ctx, a.wallet.Address())
 		if err != nil {
 			return fmt.Errorf("failed to load UTxOs for collateral selection: %w", err)
 		}
@@ -2664,11 +2685,11 @@ func (a *Apollo) restoreCollateralReservation() {
 //     ledger's implicit "all collateral inputs" rule, but it is still validated
 //     so an under-funded or asset-stranding collateral set is rejected locally
 //     rather than built into an invalid tx.
-func (a *Apollo) finalizeCollateral(fee int64) error {
+func (a *Apollo) finalizeCollateral(ctx context.Context, fee int64) error {
 	if len(a.collaterals) == 0 {
 		return nil
 	}
-	pp, err := a.Context.ProtocolParams()
+	pp, err := a.Context.ProtocolParams(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get protocol params for collateral sizing: %w", err)
 	}
@@ -2828,7 +2849,7 @@ func (a *Apollo) finalizeCollateral(fee int64) error {
 // on phase-2 script failure and regular inputs only on success; the two paths
 // are mutually exclusive. This matches mesh, lucid, and lucid-evolution and
 // lets a single-UTxO wallet build a script transaction.
-func (a *Apollo) validateCollateral() error {
+func (a *Apollo) validateCollateral(ctx context.Context) error {
 	if len(a.collaterals) == 0 {
 		return nil
 	}
@@ -2851,7 +2872,7 @@ func (a *Apollo) validateCollateral() error {
 		}
 	}
 	// Enforce the protocol max on collateral inputs when known.
-	if pp, err := a.Context.ProtocolParams(); err == nil && pp.MaxCollateralInputs > 0 &&
+	if pp, err := a.Context.ProtocolParams(ctx); err == nil && pp.MaxCollateralInputs > 0 &&
 		len(a.collaterals) > pp.MaxCollateralInputs {
 		return fmt.Errorf(
 			"too many collateral inputs: %d exceeds protocol maximum of %d",

--- a/apollo_test.go
+++ b/apollo_test.go
@@ -2,8 +2,10 @@ package apollo
 
 import (
 	"bytes"
+	"context"
 	"crypto/ed25519"
 	"encoding/hex"
+	"errors"
 	"math/big"
 	"strconv"
 	"testing"
@@ -42,6 +44,30 @@ func testAddress(t *testing.T) common.Address {
 		t.Fatal(err)
 	}
 	return addr
+}
+
+func TestCompleteContextCanceled(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	p, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AddPayment(p).
+		SetTtl(50000000).
+		CompleteContext(ctx)
+	if err == nil {
+		t.Fatal("expected canceled context error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
 }
 
 func setupFixedContext() *fixed.FixedChainContext {
@@ -1212,7 +1238,7 @@ func TestCompleteReservesReferenceScriptFeeForCoinSelection(t *testing.T) {
 	if len(inputRefs) != 2 {
 		t.Fatalf("expected both wallet UTxOs to be selected, got %v", inputRefs)
 	}
-	maxFee, err := cc.MaxTxFee()
+	maxFee, err := cc.MaxTxFee(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1406,7 +1432,7 @@ func TestSetCollateralSkipsExactMultiAssetCandidateWithoutMutatingState(t *testi
 		AttachScript(common.PlutusV2Script([]byte{0x01, 0x02})).
 		AddLoadedUTxOs(skipped, selected)
 
-	if err := a.setCollateral(); err != nil {
+	if err := a.setCollateral(context.Background()); err != nil {
 		t.Fatalf("setCollateral failed: %v", err)
 	}
 	if len(a.collaterals) != 1 {
@@ -1446,7 +1472,7 @@ func TestSetCollateralRejectedExactMultiAssetCandidateLeavesBuilderCleanOnError(
 		AttachScript(common.PlutusV2Script([]byte{0x01, 0x02})).
 		AddLoadedUTxOs(skipped)
 
-	err := a.setCollateral()
+	err := a.setCollateral(context.Background())
 	if err == nil {
 		t.Fatal("expected collateral selection error")
 	}
@@ -1702,7 +1728,7 @@ func TestSingleUtxoIsBothInputAndCollateral(t *testing.T) {
 	}
 
 	// total_collateral >= ceil(fee * collateralPercent / 100) and <= input ADA.
-	pp, _ := cc.ProtocolParams()
+	pp, _ := cc.ProtocolParams(context.Background())
 	fee := a.tx.Body.TxFee
 	required := (fee*uint64(pp.CollateralPercent) + 99) / 100 //nolint:gosec // CollateralPercent is a positive protocol parameter
 	totalColl := a.tx.Body.TxTotalCollateral

--- a/backend/base.go
+++ b/backend/base.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"math"
@@ -14,14 +15,14 @@ import (
 
 // ChainContext provides an interface for interacting with a Cardano blockchain.
 type ChainContext interface {
-	ProtocolParams() (ProtocolParameters, error)
-	GenesisParams() (GenesisParameters, error)
+	ProtocolParams(ctx context.Context) (ProtocolParameters, error)
+	GenesisParams(ctx context.Context) (GenesisParameters, error)
 	NetworkId() uint8
-	CurrentEpoch() (uint64, error)
-	MaxTxFee() (uint64, error)
-	Tip() (uint64, error)
-	Utxos(address common.Address) ([]common.Utxo, error)
-	SubmitTx(txCbor []byte) (common.Blake2b256, error)
+	CurrentEpoch(ctx context.Context) (uint64, error)
+	MaxTxFee(ctx context.Context) (uint64, error)
+	Tip(ctx context.Context) (uint64, error)
+	Utxos(ctx context.Context, address common.Address) ([]common.Utxo, error)
+	SubmitTx(ctx context.Context, txCbor []byte) (common.Blake2b256, error)
 	// EvaluateTx evaluates the scripts in a transaction and returns the
 	// execution units required by each redeemer. additionalUtxos is a set of
 	// resolved UTxOs supplied to the evaluator (e.g. spending inputs that are
@@ -33,9 +34,17 @@ type ChainContext interface {
 	// NOT support evaluation of off-chain or chained inputs. Passing non-empty
 	// additionalUtxos to such a backend is not an error, but those UTxOs will
 	// not be considered.
-	EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error)
-	UtxoByRef(txHash common.Blake2b256, index uint32) (*common.Utxo, error)
-	ScriptCbor(scriptHash common.Blake2b224) ([]byte, error)
+	EvaluateTx(ctx context.Context, txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error)
+	UtxoByRef(ctx context.Context, txHash common.Blake2b256, index uint32) (*common.Utxo, error)
+	ScriptCbor(ctx context.Context, scriptHash common.Blake2b224) ([]byte, error)
+}
+
+// ContextOrBackground returns context.Background when ctx is nil.
+func ContextOrBackground(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx
 }
 
 // GenesisParameters holds Cardano genesis configuration values.

--- a/backend/blockfrost/blockfrost.go
+++ b/backend/blockfrost/blockfrost.go
@@ -2,6 +2,7 @@ package blockfrost
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -60,9 +61,10 @@ func NewBlockFrostChainContext(baseUrl string, networkId uint8, projectId string
 	}
 }
 
-func (b *BlockFrostChainContext) request(method, path string, body io.Reader, contentType string) ([]byte, error) {
+func (b *BlockFrostChainContext) request(ctx context.Context, method, path string, body io.Reader, contentType string) ([]byte, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	url := b.baseUrl + path
-	req, err := http.NewRequest(method, url, body)
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +99,8 @@ func (b *BlockFrostChainContext) request(method, path string, body io.Reader, co
 	return data, nil
 }
 
-func (b *BlockFrostChainContext) ProtocolParams() (backend.ProtocolParameters, error) {
+func (b *BlockFrostChainContext) ProtocolParams(ctx context.Context) (backend.ProtocolParameters, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	b.mu.Lock()
 	if b.cachedParams != nil && time.Since(b.paramsCacheAt) < cacheExpiry {
 		pp := *b.cachedParams
@@ -116,7 +119,7 @@ func (b *BlockFrostChainContext) ProtocolParams() (backend.ProtocolParameters, e
 	}
 	b.mu.Unlock()
 
-	data, err := b.request("GET", "/epochs/latest/parameters", nil, "")
+	data, err := b.request(ctx, "GET", "/epochs/latest/parameters", nil, "")
 	if err != nil {
 		return backend.ProtocolParameters{}, err
 	}
@@ -151,7 +154,8 @@ func (b *BlockFrostChainContext) ProtocolParams() (backend.ProtocolParameters, e
 	return pp, nil
 }
 
-func (b *BlockFrostChainContext) GenesisParams() (backend.GenesisParameters, error) {
+func (b *BlockFrostChainContext) GenesisParams(ctx context.Context) (backend.GenesisParameters, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	b.mu.Lock()
 	if b.cachedGenesis != nil && time.Since(b.genesisCacheAt) < cacheExpiry {
 		gp := *b.cachedGenesis
@@ -160,7 +164,7 @@ func (b *BlockFrostChainContext) GenesisParams() (backend.GenesisParameters, err
 	}
 	b.mu.Unlock()
 
-	data, err := b.request("GET", "/genesis", nil, "")
+	data, err := b.request(ctx, "GET", "/genesis", nil, "")
 	if err != nil {
 		return backend.GenesisParameters{}, err
 	}
@@ -194,8 +198,9 @@ func (b *BlockFrostChainContext) NetworkId() uint8 {
 	return b.networkId
 }
 
-func (b *BlockFrostChainContext) CurrentEpoch() (uint64, error) {
-	data, err := b.request("GET", "/epochs/latest", nil, "")
+func (b *BlockFrostChainContext) CurrentEpoch(ctx context.Context) (uint64, error) {
+	ctx = backend.ContextOrBackground(ctx)
+	data, err := b.request(ctx, "GET", "/epochs/latest", nil, "")
 	if err != nil {
 		return 0, err
 	}
@@ -211,16 +216,18 @@ func (b *BlockFrostChainContext) CurrentEpoch() (uint64, error) {
 	return uint64(result.Epoch), nil
 }
 
-func (b *BlockFrostChainContext) MaxTxFee() (uint64, error) {
-	pp, err := b.ProtocolParams()
+func (b *BlockFrostChainContext) MaxTxFee(ctx context.Context) (uint64, error) {
+	ctx = backend.ContextOrBackground(ctx)
+	pp, err := b.ProtocolParams(ctx)
 	if err != nil {
 		return 0, err
 	}
 	return backend.ComputeMaxTxFee(pp)
 }
 
-func (b *BlockFrostChainContext) Tip() (uint64, error) {
-	data, err := b.request("GET", "/blocks/latest", nil, "")
+func (b *BlockFrostChainContext) Tip(ctx context.Context) (uint64, error) {
+	ctx = backend.ContextOrBackground(ctx)
+	data, err := b.request(ctx, "GET", "/blocks/latest", nil, "")
 	if err != nil {
 		return 0, err
 	}
@@ -236,13 +243,14 @@ func (b *BlockFrostChainContext) Tip() (uint64, error) {
 	return uint64(result.Slot), nil
 }
 
-func (b *BlockFrostChainContext) Utxos(address common.Address) ([]common.Utxo, error) {
+func (b *BlockFrostChainContext) Utxos(ctx context.Context, address common.Address) ([]common.Utxo, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	const maxPages = 1000
 	var allUtxos []common.Utxo
 
 	for page := 1; page <= maxPages+1; page++ {
 		path := fmt.Sprintf("/addresses/%s/utxos?page=%d", address.String(), page)
-		data, err := b.request("GET", path, nil, "")
+		data, err := b.request(ctx, "GET", path, nil, "")
 		if err != nil {
 			return nil, err
 		}
@@ -259,7 +267,7 @@ func (b *BlockFrostChainContext) Utxos(address common.Address) ([]common.Utxo, e
 		}
 
 		for _, raw := range rawUtxos {
-			utxo, err := b.hydrateUtxo(raw, address)
+			utxo, err := b.hydrateUtxo(ctx, raw, address)
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse UTxO %s#%d: %w", raw.TxHash, raw.OutputIndex, err)
 			}
@@ -269,9 +277,10 @@ func (b *BlockFrostChainContext) Utxos(address common.Address) ([]common.Utxo, e
 	return allUtxos, nil
 }
 
-func (b *BlockFrostChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error) {
+func (b *BlockFrostChainContext) SubmitTx(ctx context.Context, txCbor []byte) (common.Blake2b256, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	body := bytes.NewReader(txCbor)
-	data, err := b.request("POST", "/tx/submit", body, "application/cbor")
+	data, err := b.request(ctx, "POST", "/tx/submit", body, "application/cbor")
 	if err != nil {
 		return common.Blake2b256{}, err
 	}
@@ -291,7 +300,8 @@ func (b *BlockFrostChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, err
 	return result, nil
 }
 
-func (b *BlockFrostChainContext) EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+func (b *BlockFrostChainContext) EvaluateTx(ctx context.Context, txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	// When resolved UTxOs are supplied (e.g. inputs not yet confirmed
 	// on-chain), the bare /utils/txs/evaluate endpoint (cbor body) cannot carry
 	// them. Switch to /utils/txs/evaluate/utxos with a JSON body that includes
@@ -301,7 +311,7 @@ func (b *BlockFrostChainContext) EvaluateTx(txCbor []byte, additionalUtxos []com
 		if err != nil {
 			return nil, err
 		}
-		data, err := b.request("POST", "/utils/txs/evaluate/utxos", bytes.NewReader(reqBody), "application/json")
+		data, err := b.request(ctx, "POST", "/utils/txs/evaluate/utxos", bytes.NewReader(reqBody), "application/json")
 		if err != nil {
 			return nil, err
 		}
@@ -311,7 +321,7 @@ func (b *BlockFrostChainContext) EvaluateTx(txCbor []byte, additionalUtxos []com
 	// BlockFrost expects the transaction CBOR hex-encoded in the request body
 	// (with Content-Type application/cbor), not the raw CBOR bytes.
 	body := strings.NewReader(hex.EncodeToString(txCbor))
-	data, err := b.request("POST", "/utils/txs/evaluate", body, "application/cbor")
+	data, err := b.request(ctx, "POST", "/utils/txs/evaluate", body, "application/cbor")
 	if err != nil {
 		return nil, err
 	}
@@ -597,10 +607,11 @@ func evalErrorSnippet(data []byte) string {
 	return string(data)
 }
 
-func (b *BlockFrostChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) (*common.Utxo, error) {
+func (b *BlockFrostChainContext) UtxoByRef(ctx context.Context, txHash common.Blake2b256, index uint32) (*common.Utxo, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	hashHex := hex.EncodeToString(txHash.Bytes())
 	path := fmt.Sprintf("/txs/%s/utxos", hashHex)
-	data, err := b.request("GET", path, nil, "")
+	data, err := b.request(ctx, "GET", path, nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -618,7 +629,7 @@ func (b *BlockFrostChainContext) UtxoByRef(txHash common.Blake2b256, index uint3
 			if err != nil {
 				return nil, err
 			}
-			utxo, err := b.hydrateUtxo(raw, addr)
+			utxo, err := b.hydrateUtxo(ctx, raw, addr)
 			if err != nil {
 				return nil, err
 			}
@@ -628,10 +639,11 @@ func (b *BlockFrostChainContext) UtxoByRef(txHash common.Blake2b256, index uint3
 	return nil, errors.New("utxo not found")
 }
 
-func (b *BlockFrostChainContext) ScriptCbor(scriptHash common.Blake2b224) ([]byte, error) {
+func (b *BlockFrostChainContext) ScriptCbor(ctx context.Context, scriptHash common.Blake2b224) ([]byte, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	hashHex := hex.EncodeToString(scriptHash.Bytes())
 	path := fmt.Sprintf("/scripts/%s/cbor", hashHex)
-	data, err := b.request("GET", path, nil, "")
+	data, err := b.request(ctx, "GET", path, nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -933,7 +945,7 @@ func (raw *bfAddressUTxO) toUtxo(address common.Address) (common.Utxo, error) {
 	}, nil
 }
 
-func (b *BlockFrostChainContext) hydrateUtxo(raw bfAddressUTxO, address common.Address) (common.Utxo, error) {
+func (b *BlockFrostChainContext) hydrateUtxo(ctx context.Context, raw bfAddressUTxO, address common.Address) (common.Utxo, error) {
 	utxo, err := raw.toUtxo(address)
 	if err != nil {
 		return common.Utxo{}, err
@@ -950,7 +962,7 @@ func (b *BlockFrostChainContext) hydrateUtxo(raw bfAddressUTxO, address common.A
 		output.DatumOption = datumOpt
 	}
 	if raw.ReferenceScriptHash != "" {
-		scriptRef, err := b.scriptRefByHash(raw.ReferenceScriptHash)
+		scriptRef, err := b.scriptRefByHash(ctx, raw.ReferenceScriptHash)
 		if err != nil {
 			return common.Utxo{}, fmt.Errorf("failed to resolve reference script %s: %w", raw.ReferenceScriptHash, err)
 		}
@@ -984,7 +996,7 @@ func inlineDatumOptionFromBlockfrost(raw json.RawMessage) (*babbage.BabbageTrans
 	return &opt, nil
 }
 
-func (b *BlockFrostChainContext) scriptRefByHash(hashHex string) (*common.ScriptRef, error) {
+func (b *BlockFrostChainContext) scriptRefByHash(ctx context.Context, hashHex string) (*common.ScriptRef, error) {
 	hashBytes, err := hex.DecodeString(hashHex)
 	if err != nil {
 		return nil, fmt.Errorf("invalid script hash hex %q: %w", hashHex, err)
@@ -994,7 +1006,7 @@ func (b *BlockFrostChainContext) scriptRefByHash(hashHex string) (*common.Script
 	}
 	var scriptHash common.Blake2b224
 	copy(scriptHash[:], hashBytes)
-	scriptCbor, err := b.ScriptCbor(scriptHash)
+	scriptCbor, err := b.ScriptCbor(ctx, scriptHash)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/blockfrost/blockfrost_test.go
+++ b/backend/blockfrost/blockfrost_test.go
@@ -2,8 +2,10 @@ package blockfrost
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
 	"math"
 	"math/big"
@@ -11,6 +13,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
@@ -60,7 +63,7 @@ func TestHydrateUtxoResolvesInlineDatumAndReferenceScript(t *testing.T) {
 		ReferenceScriptHash: scriptHashHex,
 	}
 
-	utxo, err := ctx.hydrateUtxo(raw, addr)
+	utxo, err := ctx.hydrateUtxo(context.Background(), raw, addr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,9 +108,48 @@ func TestEvaluateTxRejectsRedeemerIndexOverflow(t *testing.T) {
 	defer server.Close()
 
 	ctx := NewBlockFrostChainContext(server.URL, 0, "")
-	_, err := ctx.EvaluateTx([]byte{0x84}, nil)
+	_, err := ctx.EvaluateTx(context.Background(), []byte{0x84}, nil)
 	if err == nil {
 		t.Fatal("expected redeemer index overflow error")
+	}
+}
+
+func TestCurrentEpochUsesRequestContext(t *testing.T) {
+	started := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v0/epochs/latest" {
+			http.NotFound(w, r)
+			return
+		}
+		close(started)
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bfc := NewBlockFrostChainContext(server.URL, 0, "")
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := bfc.CurrentEpoch(ctx)
+		errCh <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Blockfrost request")
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for canceled request")
 	}
 }
 
@@ -133,7 +175,7 @@ func TestEvaluateTxSendsHexEncodedBody(t *testing.T) {
 	defer server.Close()
 
 	ctx := NewBlockFrostChainContext(server.URL, 0, "")
-	result, err := ctx.EvaluateTx(txCbor, nil)
+	result, err := ctx.EvaluateTx(context.Background(), txCbor, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -634,7 +676,7 @@ func TestEvaluateTxWithAdditionalUtxosTargetsUtxosEndpoint(t *testing.T) {
 	defer server.Close()
 
 	ctx := NewBlockFrostChainContext(server.URL, 0, "")
-	result, err := ctx.EvaluateTx([]byte{0x84}, []common.Utxo{sampleCommonUtxo(t)})
+	result, err := ctx.EvaluateTx(context.Background(), []byte{0x84}, []common.Utxo{sampleCommonUtxo(t)})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/cache/cache.go
+++ b/backend/cache/cache.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -29,7 +30,8 @@ func NewCachedChainContext(inner backend.ChainContext, ttl time.Duration) *Cache
 	}
 }
 
-func (c *CachedChainContext) ProtocolParams() (backend.ProtocolParameters, error) {
+func (c *CachedChainContext) ProtocolParams(ctx context.Context) (backend.ProtocolParameters, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	c.mu.Lock()
 	if c.cachedParams != nil && time.Since(c.paramsCacheAt) < c.ttl {
 		pp := *c.cachedParams
@@ -48,7 +50,7 @@ func (c *CachedChainContext) ProtocolParams() (backend.ProtocolParameters, error
 	}
 	c.mu.Unlock()
 
-	pp, err := c.inner.ProtocolParams()
+	pp, err := c.inner.ProtocolParams(ctx)
 	if err != nil {
 		return pp, err
 	}
@@ -73,7 +75,8 @@ func (c *CachedChainContext) ProtocolParams() (backend.ProtocolParameters, error
 	return pp, nil
 }
 
-func (c *CachedChainContext) GenesisParams() (backend.GenesisParameters, error) {
+func (c *CachedChainContext) GenesisParams(ctx context.Context) (backend.GenesisParameters, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	c.mu.Lock()
 	if c.cachedGenesis != nil && time.Since(c.genesisCacheAt) < c.ttl {
 		gp := *c.cachedGenesis
@@ -82,7 +85,7 @@ func (c *CachedChainContext) GenesisParams() (backend.GenesisParameters, error) 
 	}
 	c.mu.Unlock()
 
-	gp, err := c.inner.GenesisParams()
+	gp, err := c.inner.GenesisParams(ctx)
 	if err != nil {
 		return gp, err
 	}
@@ -99,34 +102,34 @@ func (c *CachedChainContext) NetworkId() uint8 {
 	return c.inner.NetworkId()
 }
 
-func (c *CachedChainContext) CurrentEpoch() (uint64, error) {
-	return c.inner.CurrentEpoch()
+func (c *CachedChainContext) CurrentEpoch(ctx context.Context) (uint64, error) {
+	return c.inner.CurrentEpoch(backend.ContextOrBackground(ctx))
 }
 
-func (c *CachedChainContext) MaxTxFee() (uint64, error) {
-	return c.inner.MaxTxFee()
+func (c *CachedChainContext) MaxTxFee(ctx context.Context) (uint64, error) {
+	return c.inner.MaxTxFee(backend.ContextOrBackground(ctx))
 }
 
-func (c *CachedChainContext) Tip() (uint64, error) {
-	return c.inner.Tip()
+func (c *CachedChainContext) Tip(ctx context.Context) (uint64, error) {
+	return c.inner.Tip(backend.ContextOrBackground(ctx))
 }
 
-func (c *CachedChainContext) Utxos(address common.Address) ([]common.Utxo, error) {
-	return c.inner.Utxos(address)
+func (c *CachedChainContext) Utxos(ctx context.Context, address common.Address) ([]common.Utxo, error) {
+	return c.inner.Utxos(backend.ContextOrBackground(ctx), address)
 }
 
-func (c *CachedChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error) {
-	return c.inner.SubmitTx(txCbor)
+func (c *CachedChainContext) SubmitTx(ctx context.Context, txCbor []byte) (common.Blake2b256, error) {
+	return c.inner.SubmitTx(backend.ContextOrBackground(ctx), txCbor)
 }
 
-func (c *CachedChainContext) EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
-	return c.inner.EvaluateTx(txCbor, additionalUtxos)
+func (c *CachedChainContext) EvaluateTx(ctx context.Context, txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+	return c.inner.EvaluateTx(backend.ContextOrBackground(ctx), txCbor, additionalUtxos)
 }
 
-func (c *CachedChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) (*common.Utxo, error) {
-	return c.inner.UtxoByRef(txHash, index)
+func (c *CachedChainContext) UtxoByRef(ctx context.Context, txHash common.Blake2b256, index uint32) (*common.Utxo, error) {
+	return c.inner.UtxoByRef(backend.ContextOrBackground(ctx), txHash, index)
 }
 
-func (c *CachedChainContext) ScriptCbor(scriptHash common.Blake2b224) ([]byte, error) {
-	return c.inner.ScriptCbor(scriptHash)
+func (c *CachedChainContext) ScriptCbor(ctx context.Context, scriptHash common.Blake2b224) ([]byte, error) {
+	return c.inner.ScriptCbor(backend.ContextOrBackground(ctx), scriptHash)
 }

--- a/backend/cache/cache_test.go
+++ b/backend/cache/cache_test.go
@@ -15,6 +15,8 @@ type contextRecordingChainContext struct {
 	got context.Context
 }
 
+type contextTestKey struct{}
+
 func (c *contextRecordingChainContext) Utxos(ctx context.Context, address common.Address) ([]common.Utxo, error) {
 	c.got = ctx
 	return c.FixedChainContext.Utxos(ctx, address)
@@ -23,7 +25,7 @@ func (c *contextRecordingChainContext) Utxos(ctx context.Context, address common
 func TestCachedChainContextPassesContextThrough(t *testing.T) {
 	inner := &contextRecordingChainContext{FixedChainContext: fixed.NewEmptyFixedChainContext()}
 	cached := NewCachedChainContext(inner, time.Minute)
-	ctx := context.WithValue(context.Background(), struct{}{}, "marker")
+	ctx := context.WithValue(context.Background(), contextTestKey{}, "marker")
 
 	_, err := cached.Utxos(ctx, common.Address{})
 	if err != nil {

--- a/backend/cache/cache_test.go
+++ b/backend/cache/cache_test.go
@@ -1,0 +1,35 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+
+	"github.com/Salvionied/apollo/v2/backend/fixed"
+)
+
+type contextRecordingChainContext struct {
+	*fixed.FixedChainContext
+	got context.Context
+}
+
+func (c *contextRecordingChainContext) Utxos(ctx context.Context, address common.Address) ([]common.Utxo, error) {
+	c.got = ctx
+	return c.FixedChainContext.Utxos(ctx, address)
+}
+
+func TestCachedChainContextPassesContextThrough(t *testing.T) {
+	inner := &contextRecordingChainContext{FixedChainContext: fixed.NewEmptyFixedChainContext()}
+	cached := NewCachedChainContext(inner, time.Minute)
+	ctx := context.WithValue(context.Background(), struct{}{}, "marker")
+
+	_, err := cached.Utxos(ctx, common.Address{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inner.got != ctx {
+		t.Fatalf("inner backend got context %p, want %p", inner.got, ctx)
+	}
+}

--- a/backend/fixed/fixed.go
+++ b/backend/fixed/fixed.go
@@ -1,6 +1,7 @@
 package fixed
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
 	"strconv"
@@ -82,7 +83,10 @@ func utxoRefKey(txHash common.Blake2b256, index uint32) string {
 	return hex.EncodeToString(txHash.Bytes()) + "#" + strconv.Itoa(int(index))
 }
 
-func (f *FixedChainContext) ProtocolParams() (backend.ProtocolParameters, error) {
+func (f *FixedChainContext) ProtocolParams(ctx context.Context) (backend.ProtocolParameters, error) {
+	if err := backend.ContextOrBackground(ctx).Err(); err != nil {
+		return backend.ProtocolParameters{}, err
+	}
 	pp := f.protocolParams
 	if pp.CostModels != nil {
 		cm := make(map[string][]int64, len(pp.CostModels))
@@ -96,7 +100,10 @@ func (f *FixedChainContext) ProtocolParams() (backend.ProtocolParameters, error)
 	return pp, nil
 }
 
-func (f *FixedChainContext) GenesisParams() (backend.GenesisParameters, error) {
+func (f *FixedChainContext) GenesisParams(ctx context.Context) (backend.GenesisParameters, error) {
+	if err := backend.ContextOrBackground(ctx).Err(); err != nil {
+		return backend.GenesisParameters{}, err
+	}
 	return f.genesisParams, nil
 }
 
@@ -104,23 +111,33 @@ func (f *FixedChainContext) NetworkId() uint8 {
 	return f.networkId
 }
 
-func (f *FixedChainContext) CurrentEpoch() (uint64, error) {
+func (f *FixedChainContext) CurrentEpoch(ctx context.Context) (uint64, error) {
+	if err := backend.ContextOrBackground(ctx).Err(); err != nil {
+		return 0, err
+	}
 	return 0, nil
 }
 
-func (f *FixedChainContext) MaxTxFee() (uint64, error) {
-	pp, err := f.ProtocolParams()
+func (f *FixedChainContext) MaxTxFee(ctx context.Context) (uint64, error) {
+	ctx = backend.ContextOrBackground(ctx)
+	pp, err := f.ProtocolParams(ctx)
 	if err != nil {
 		return 0, err
 	}
 	return backend.ComputeMaxTxFee(pp)
 }
 
-func (f *FixedChainContext) Tip() (uint64, error) {
+func (f *FixedChainContext) Tip(ctx context.Context) (uint64, error) {
+	if err := backend.ContextOrBackground(ctx).Err(); err != nil {
+		return 0, err
+	}
 	return 0, nil
 }
 
-func (f *FixedChainContext) Utxos(address common.Address) ([]common.Utxo, error) {
+func (f *FixedChainContext) Utxos(ctx context.Context, address common.Address) ([]common.Utxo, error) {
+	if err := backend.ContextOrBackground(ctx).Err(); err != nil {
+		return nil, err
+	}
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 	src := f.utxos[address.String()]
@@ -129,15 +146,24 @@ func (f *FixedChainContext) Utxos(address common.Address) ([]common.Utxo, error)
 	return result, nil
 }
 
-func (f *FixedChainContext) SubmitTx(_ []byte) (common.Blake2b256, error) {
+func (f *FixedChainContext) SubmitTx(ctx context.Context, _ []byte) (common.Blake2b256, error) {
+	if err := backend.ContextOrBackground(ctx).Err(); err != nil {
+		return common.Blake2b256{}, err
+	}
 	return common.Blake2b256{}, errors.New("cannot submit tx with fixed chain context")
 }
 
-func (f *FixedChainContext) EvaluateTx(_ []byte, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+func (f *FixedChainContext) EvaluateTx(ctx context.Context, _ []byte, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+	if err := backend.ContextOrBackground(ctx).Err(); err != nil {
+		return nil, err
+	}
 	return nil, errors.New("cannot evaluate tx with fixed chain context")
 }
 
-func (f *FixedChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) (*common.Utxo, error) {
+func (f *FixedChainContext) UtxoByRef(ctx context.Context, txHash common.Blake2b256, index uint32) (*common.Utxo, error) {
+	if err := backend.ContextOrBackground(ctx).Err(); err != nil {
+		return nil, err
+	}
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 	if utxo, ok := f.utxosByRef[utxoRefKey(txHash, index)]; ok {
@@ -147,6 +173,9 @@ func (f *FixedChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) (*
 	return nil, errors.New("utxo not found in fixed chain context")
 }
 
-func (f *FixedChainContext) ScriptCbor(_ common.Blake2b224) ([]byte, error) {
+func (f *FixedChainContext) ScriptCbor(ctx context.Context, _ common.Blake2b224) ([]byte, error) {
+	if err := backend.ContextOrBackground(ctx).Err(); err != nil {
+		return nil, err
+	}
 	return nil, errors.New("not implemented in fixed chain context")
 }

--- a/backend/maestro/maestro.go
+++ b/backend/maestro/maestro.go
@@ -31,9 +31,7 @@ type MaestroChainContext struct {
 	client    *maestroClient.Client
 	networkId uint8
 	// apiKey is retained alongside the SDK client because the SDK keeps its
-	// own copy unexported. EvaluateTx with additional UTxOs issues a raw POST
-	// (the SDK's additional_utxos field is []string and cannot carry the
-	// object-shaped entries Maestro requires) and needs the key for auth.
+	// own copy unexported and Apollo issues raw context-aware HTTP requests.
 	apiKey string
 }
 
@@ -86,11 +84,8 @@ func NewMaestroChainContextWithNetwork(networkId uint8, projectId string, networ
 
 func (m *MaestroChainContext) ProtocolParams(ctx context.Context) (backend.ProtocolParameters, error) {
 	ctx = backend.ContextOrBackground(ctx)
-	if err := ctx.Err(); err != nil {
-		return backend.ProtocolParameters{}, err
-	}
-	resp, err := m.client.ProtocolParameters()
-	if err != nil {
+	var resp models.ProtocolParameters
+	if err := m.getJSON(ctx, "/protocol-parameters", &resp); err != nil {
 		return backend.ProtocolParameters{}, err
 	}
 
@@ -192,11 +187,8 @@ func (m *MaestroChainContext) NetworkId() uint8 {
 
 func (m *MaestroChainContext) CurrentEpoch(ctx context.Context) (uint64, error) {
 	ctx = backend.ContextOrBackground(ctx)
-	if err := ctx.Err(); err != nil {
-		return 0, err
-	}
-	resp, err := m.client.CurrentEpoch()
-	if err != nil {
+	var resp models.EpochResp
+	if err := m.getJSON(ctx, "/epochs/current", &resp); err != nil {
 		return 0, err
 	}
 	if resp.Data.EpochNo < 0 {
@@ -216,11 +208,8 @@ func (m *MaestroChainContext) MaxTxFee(ctx context.Context) (uint64, error) {
 
 func (m *MaestroChainContext) Tip(ctx context.Context) (uint64, error) {
 	ctx = backend.ContextOrBackground(ctx)
-	if err := ctx.Err(); err != nil {
-		return 0, err
-	}
-	resp, err := m.client.ChainTip()
-	if err != nil {
+	var resp models.ChainTip
+	if err := m.getJSON(ctx, "/chain-tip", &resp); err != nil {
 		return 0, err
 	}
 	if resp.Data.Slot < 0 {
@@ -240,8 +229,9 @@ func (m *MaestroChainContext) Utxos(ctx context.Context, address common.Address)
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		resp, err := m.client.UtxosAtAddress(address.String(), params)
-		if err != nil {
+		path := fmt.Sprintf("/addresses/%s/utxos%s", address.String(), params.Format())
+		var resp models.UtxosAtAddress
+		if err := m.getJSON(ctx, path, &resp); err != nil {
 			return nil, err
 		}
 
@@ -270,21 +260,16 @@ func (m *MaestroChainContext) Utxos(ctx context.Context, address common.Address)
 
 func (m *MaestroChainContext) SubmitTx(ctx context.Context, txCbor []byte) (common.Blake2b256, error) {
 	ctx = backend.ContextOrBackground(ctx)
-	if err := ctx.Err(); err != nil {
-		return common.Blake2b256{}, err
-	}
 	// The Maestro SDK's Client.SubmitTx posts to a corrupted URL
-	// ("/submitmodels.BasicResponse{}/tx") and can never work. Use
-	// TxManagerSubmit instead, which posts the hex-encoded transaction
-	// CBOR to the documented POST /txmanager submit endpoint.
-	txCborHex := hex.EncodeToString(txCbor)
-	txHash, err := m.client.TxManagerSubmit(txCborHex)
+	// ("/submitmodels.BasicResponse{}/tx") and can never work. Use the
+	// documented POST /txmanager endpoint directly, preserving caller context.
+	data, err := m.request(ctx, http.MethodPost, "/txmanager", bytes.NewReader(txCbor), "application/cbor", "application/cbor", http.StatusOK, http.StatusAccepted)
 	if err != nil {
 		return common.Blake2b256{}, fmt.Errorf("maestro tx submission failed: %w", err)
 	}
 	// The endpoint returns the tx hash as a plain-text body; tolerate JSON
 	// string quoting and surrounding whitespace.
-	txHash = strings.Trim(strings.TrimSpace(txHash), `"`)
+	txHash := strings.Trim(strings.TrimSpace(string(data)), `"`)
 	hashBytes, err := hex.DecodeString(txHash)
 	if err != nil {
 		return common.Blake2b256{}, fmt.Errorf("invalid tx hash %q in submit response: %w", txHash, err)
@@ -298,22 +283,21 @@ func (m *MaestroChainContext) SubmitTx(ctx context.Context, txCbor []byte) (comm
 }
 
 // EvaluateTx evaluates the script execution budgets for a transaction. When
-// additionalUtxos is empty it uses the Maestro SDK's EvaluateTx, which posts the
-// bare tx CBOR. When resolved UTxOs are supplied (e.g. off-chain or chained
-// inputs not yet visible to Maestro) it issues a raw POST to
-// /transactions/evaluate with the documented object-shaped additional_utxos
-// field. The SDK's own additional_utxos type is []string and cannot represent
-// the required {tx_hash, index, txout_cbor} entries, so the request is built
-// here against the SDK client's base URL and API key.
+// resolved UTxOs are supplied (e.g. off-chain or chained inputs not yet visible
+// to Maestro), it sends the documented object-shaped additional_utxos field.
+// The Maestro SDK's additional_utxos type is []string and cannot represent the
+// required {tx_hash, index, txout_cbor} entries, so the request is built here
+// against the SDK client's base URL and API key.
 func (m *MaestroChainContext) EvaluateTx(ctx context.Context, txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
 	ctx = backend.ContextOrBackground(ctx)
 	txHex := hex.EncodeToString(txCbor)
 
 	if len(additionalUtxos) == 0 {
-		if err := ctx.Err(); err != nil {
-			return nil, err
+		reqBody, err := json.Marshal(models.EvaluateTx{Cbor: txHex})
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal evaluate request: %w", err)
 		}
-		evalResp, err := m.client.EvaluateTx(txHex)
+		evalResp, err := m.postEvaluate(ctx, reqBody)
 		if err != nil {
 			return nil, err
 		}
@@ -394,32 +378,12 @@ func maestroAdditionalUtxoFromUtxo(utxo common.Utxo) (maestroAdditionalUtxo, err
 // same shape the SDK uses.
 func (m *MaestroChainContext) postEvaluate(ctx context.Context, body []byte) (models.EvaluateTxResponse, error) {
 	ctx = backend.ContextOrBackground(ctx)
-	url := m.client.BaseUrl + "/transactions/evaluate"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	data, err := m.request(ctx, http.MethodPost, "/transactions/evaluate", bytes.NewReader(body), "application/json", "application/json", http.StatusOK)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("api-key", m.apiKey)
-
-	httpClient := m.client.HTTPClient
-	if httpClient == nil {
-		httpClient = http.DefaultClient
-	}
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		msg, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("maestro evaluate failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(msg)))
-	}
-
 	var evalResp models.EvaluateTxResponse
-	if err := json.NewDecoder(resp.Body).Decode(&evalResp); err != nil {
+	if err := json.Unmarshal(data, &evalResp); err != nil {
 		return nil, fmt.Errorf("failed to decode evaluate response: %w", err)
 	}
 	return evalResp, nil
@@ -453,12 +417,10 @@ func evaluationsToExUnits(evals models.EvaluateTxResponse) (map[common.RedeemerK
 
 func (m *MaestroChainContext) UtxoByRef(ctx context.Context, txHash common.Blake2b256, index uint32) (*common.Utxo, error) {
 	ctx = backend.ContextOrBackground(ctx)
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
 	hashHex := hex.EncodeToString(txHash.Bytes())
-	resp, err := m.client.TransactionOutputFromReference(hashHex, int(index), nil)
-	if err != nil {
+	var resp models.TransactionOutputFromReference
+	path := fmt.Sprintf("/transactions/%s/outputs/%d/txo", hashHex, index)
+	if err := m.getJSON(ctx, path, &resp); err != nil {
 		return nil, err
 	}
 
@@ -475,18 +437,65 @@ func (m *MaestroChainContext) UtxoByRef(ctx context.Context, txHash common.Blake
 
 func (m *MaestroChainContext) ScriptCbor(ctx context.Context, scriptHash common.Blake2b224) ([]byte, error) {
 	ctx = backend.ContextOrBackground(ctx)
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
 	hashHex := hex.EncodeToString(scriptHash.Bytes())
-	resp, err := m.client.ScriptByHash(hashHex)
-	if err != nil {
+	var resp models.ScriptByHash
+	if err := m.getJSON(ctx, "/scripts/"+hashHex, &resp); err != nil {
 		return nil, err
 	}
 	if resp.Data.Bytes == "" {
 		return nil, errors.New("no script CBOR available")
 	}
 	return hex.DecodeString(resp.Data.Bytes)
+}
+
+func (m *MaestroChainContext) getJSON(ctx context.Context, path string, out any) error {
+	data, err := m.request(ctx, http.MethodGet, path, nil, "", "application/json", http.StatusOK)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("failed to decode maestro response: %w", err)
+	}
+	return nil
+}
+
+func (m *MaestroChainContext) request(ctx context.Context, method string, path string, body io.Reader, contentType string, accept string, okStatuses ...int) ([]byte, error) {
+	ctx = backend.ContextOrBackground(ctx)
+	req, err := http.NewRequestWithContext(ctx, method, m.client.BaseUrl+path, body)
+	if err != nil {
+		return nil, err
+	}
+	if accept != "" {
+		req.Header.Set("Accept", accept)
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	req.Header.Set("api-key", m.apiKey)
+
+	httpClient := m.client.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || resp.Body == nil {
+		return nil, errors.New("maestro: nil response")
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	for _, status := range okStatuses {
+		if resp.StatusCode == status {
+			return data, nil
+		}
+	}
+	return nil, fmt.Errorf("maestro API error %d: %s", resp.StatusCode, strings.TrimSpace(string(data)))
 }
 
 func maestroUtxoToCommon(raw models.Utxo, address common.Address) (common.Utxo, error) {

--- a/backend/maestro/maestro.go
+++ b/backend/maestro/maestro.go
@@ -2,6 +2,7 @@ package maestro
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -83,7 +84,11 @@ func NewMaestroChainContextWithNetwork(networkId uint8, projectId string, networ
 	}, nil
 }
 
-func (m *MaestroChainContext) ProtocolParams() (backend.ProtocolParameters, error) {
+func (m *MaestroChainContext) ProtocolParams(ctx context.Context) (backend.ProtocolParameters, error) {
+	ctx = backend.ContextOrBackground(ctx)
+	if err := ctx.Err(); err != nil {
+		return backend.ProtocolParameters{}, err
+	}
 	resp, err := m.client.ProtocolParameters()
 	if err != nil {
 		return backend.ProtocolParameters{}, err
@@ -174,7 +179,10 @@ func (m *MaestroChainContext) ProtocolParams() (backend.ProtocolParameters, erro
 	return pp, nil
 }
 
-func (m *MaestroChainContext) GenesisParams() (backend.GenesisParameters, error) {
+func (m *MaestroChainContext) GenesisParams(ctx context.Context) (backend.GenesisParameters, error) {
+	if err := backend.ContextOrBackground(ctx).Err(); err != nil {
+		return backend.GenesisParameters{}, err
+	}
 	return backend.GenesisParameters{}, errors.New("genesis params not available via Maestro API")
 }
 
@@ -182,7 +190,11 @@ func (m *MaestroChainContext) NetworkId() uint8 {
 	return m.networkId
 }
 
-func (m *MaestroChainContext) CurrentEpoch() (uint64, error) {
+func (m *MaestroChainContext) CurrentEpoch(ctx context.Context) (uint64, error) {
+	ctx = backend.ContextOrBackground(ctx)
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
 	resp, err := m.client.CurrentEpoch()
 	if err != nil {
 		return 0, err
@@ -193,15 +205,20 @@ func (m *MaestroChainContext) CurrentEpoch() (uint64, error) {
 	return uint64(resp.Data.EpochNo), nil
 }
 
-func (m *MaestroChainContext) MaxTxFee() (uint64, error) {
-	pp, err := m.ProtocolParams()
+func (m *MaestroChainContext) MaxTxFee(ctx context.Context) (uint64, error) {
+	ctx = backend.ContextOrBackground(ctx)
+	pp, err := m.ProtocolParams(ctx)
 	if err != nil {
 		return 0, err
 	}
 	return backend.ComputeMaxTxFee(pp)
 }
 
-func (m *MaestroChainContext) Tip() (uint64, error) {
+func (m *MaestroChainContext) Tip(ctx context.Context) (uint64, error) {
+	ctx = backend.ContextOrBackground(ctx)
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
 	resp, err := m.client.ChainTip()
 	if err != nil {
 		return 0, err
@@ -212,13 +229,17 @@ func (m *MaestroChainContext) Tip() (uint64, error) {
 	return uint64(resp.Data.Slot), nil
 }
 
-func (m *MaestroChainContext) Utxos(address common.Address) ([]common.Utxo, error) {
+func (m *MaestroChainContext) Utxos(ctx context.Context, address common.Address) ([]common.Utxo, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	const maxPages = 1000
 	var allUtxos []common.Utxo
 	params := utils.NewParameters()
 	var lastCursor string
 
 	for range maxPages {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		resp, err := m.client.UtxosAtAddress(address.String(), params)
 		if err != nil {
 			return nil, err
@@ -247,7 +268,11 @@ func (m *MaestroChainContext) Utxos(address common.Address) ([]common.Utxo, erro
 	return allUtxos, nil
 }
 
-func (m *MaestroChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error) {
+func (m *MaestroChainContext) SubmitTx(ctx context.Context, txCbor []byte) (common.Blake2b256, error) {
+	ctx = backend.ContextOrBackground(ctx)
+	if err := ctx.Err(); err != nil {
+		return common.Blake2b256{}, err
+	}
 	// The Maestro SDK's Client.SubmitTx posts to a corrupted URL
 	// ("/submitmodels.BasicResponse{}/tx") and can never work. Use
 	// TxManagerSubmit instead, which posts the hex-encoded transaction
@@ -280,10 +305,14 @@ func (m *MaestroChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error)
 // field. The SDK's own additional_utxos type is []string and cannot represent
 // the required {tx_hash, index, txout_cbor} entries, so the request is built
 // here against the SDK client's base URL and API key.
-func (m *MaestroChainContext) EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+func (m *MaestroChainContext) EvaluateTx(ctx context.Context, txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	txHex := hex.EncodeToString(txCbor)
 
 	if len(additionalUtxos) == 0 {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		evalResp, err := m.client.EvaluateTx(txHex)
 		if err != nil {
 			return nil, err
@@ -295,7 +324,7 @@ func (m *MaestroChainContext) EvaluateTx(txCbor []byte, additionalUtxos []common
 	if err != nil {
 		return nil, err
 	}
-	evalResp, err := m.postEvaluate(reqBody)
+	evalResp, err := m.postEvaluate(ctx, reqBody)
 	if err != nil {
 		return nil, err
 	}
@@ -363,9 +392,10 @@ func maestroAdditionalUtxoFromUtxo(utxo common.Utxo) (maestroAdditionalUtxo, err
 // postEvaluate issues a raw POST to /transactions/evaluate, reusing the SDK
 // client's base URL, API key and HTTP client, and decodes the response with the
 // same shape the SDK uses.
-func (m *MaestroChainContext) postEvaluate(body []byte) (models.EvaluateTxResponse, error) {
+func (m *MaestroChainContext) postEvaluate(ctx context.Context, body []byte) (models.EvaluateTxResponse, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	url := m.client.BaseUrl + "/transactions/evaluate"
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -421,7 +451,11 @@ func evaluationsToExUnits(evals models.EvaluateTxResponse) (map[common.RedeemerK
 	return result, nil
 }
 
-func (m *MaestroChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) (*common.Utxo, error) {
+func (m *MaestroChainContext) UtxoByRef(ctx context.Context, txHash common.Blake2b256, index uint32) (*common.Utxo, error) {
+	ctx = backend.ContextOrBackground(ctx)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	hashHex := hex.EncodeToString(txHash.Bytes())
 	resp, err := m.client.TransactionOutputFromReference(hashHex, int(index), nil)
 	if err != nil {
@@ -439,7 +473,11 @@ func (m *MaestroChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) 
 	return &utxo, nil
 }
 
-func (m *MaestroChainContext) ScriptCbor(scriptHash common.Blake2b224) ([]byte, error) {
+func (m *MaestroChainContext) ScriptCbor(ctx context.Context, scriptHash common.Blake2b224) ([]byte, error) {
+	ctx = backend.ContextOrBackground(ctx)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	hashHex := hex.EncodeToString(scriptHash.Bytes())
 	resp, err := m.client.ScriptByHash(hashHex)
 	if err != nil {

--- a/backend/maestro/maestro.go
+++ b/backend/maestro/maestro.go
@@ -263,7 +263,7 @@ func (m *MaestroChainContext) SubmitTx(ctx context.Context, txCbor []byte) (comm
 	// The Maestro SDK's Client.SubmitTx posts to a corrupted URL
 	// ("/submitmodels.BasicResponse{}/tx") and can never work. Use the
 	// documented POST /txmanager endpoint directly, preserving caller context.
-	data, err := m.request(ctx, http.MethodPost, "/txmanager", bytes.NewReader(txCbor), "application/cbor", "application/cbor", http.StatusOK, http.StatusAccepted)
+	data, err := m.request(ctx, http.MethodPost, "/txmanager", bytes.NewReader(txCbor), "application/cbor", "text/plain", http.StatusOK, http.StatusAccepted)
 	if err != nil {
 		return common.Blake2b256{}, fmt.Errorf("maestro tx submission failed: %w", err)
 	}

--- a/backend/maestro/maestro_test.go
+++ b/backend/maestro/maestro_test.go
@@ -2,6 +2,7 @@ package maestro
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"io"
@@ -215,7 +216,7 @@ func TestSubmitTxPostsCborToTxManager(t *testing.T) {
 	}
 	ctx.client.BaseUrl = server.URL
 
-	txHash, err := ctx.SubmitTx(txCbor)
+	txHash, err := ctx.SubmitTx(context.Background(), txCbor)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -343,7 +344,7 @@ func TestEvaluateTxWithAdditionalUtxosPostsObjectShape(t *testing.T) {
 	}
 	ctx.client.BaseUrl = server.URL
 
-	result, err := ctx.EvaluateTx([]byte{0x84, 0xa3, 0x00}, []common.Utxo{utxo})
+	result, err := ctx.EvaluateTx(context.Background(), []byte{0x84, 0xa3, 0x00}, []common.Utxo{utxo})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -399,7 +400,7 @@ func TestEvaluateTxEmptyAdditionalUtxosUsesSdkPath(t *testing.T) {
 			}
 			ctx.client.BaseUrl = server.URL
 
-			result, err := ctx.EvaluateTx([]byte{0x84}, tc.utxos)
+			result, err := ctx.EvaluateTx(context.Background(), []byte{0x84}, tc.utxos)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -455,7 +456,7 @@ func TestEvaluateTxWithAdditionalUtxosPropagatesHTTPError(t *testing.T) {
 	}
 	ctx.client.BaseUrl = server.URL
 
-	if _, err := ctx.EvaluateTx([]byte{0x84}, []common.Utxo{utxo}); err == nil {
+	if _, err := ctx.EvaluateTx(context.Background(), []byte{0x84}, []common.Utxo{utxo}); err == nil {
 		t.Fatal("expected error for non-200 evaluate response")
 	}
 }

--- a/backend/maestro/maestro_test.go
+++ b/backend/maestro/maestro_test.go
@@ -197,10 +197,11 @@ func TestNewMaestroChainContextWithNetworkAllowlist(t *testing.T) {
 func TestSubmitTxPostsCborToTxManager(t *testing.T) {
 	txCbor := []byte{0x84, 0xa3, 0x00}
 	wantHash := bytes.Repeat([]byte{0xab}, common.Blake2b256Size)
-	var gotPath, gotContentType string
+	var gotPath, gotAccept, gotContentType string
 	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
+		gotAccept = r.Header.Get("Accept")
 		gotContentType = r.Header.Get("Content-Type")
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -224,6 +225,9 @@ func TestSubmitTxPostsCborToTxManager(t *testing.T) {
 	}
 	if gotPath != "/txmanager" {
 		t.Fatalf("submit path = %q, want /txmanager", gotPath)
+	}
+	if gotAccept != "text/plain" {
+		t.Fatalf("Accept = %q, want text/plain", gotAccept)
 	}
 	if gotContentType != "application/cbor" {
 		t.Fatalf("Content-Type = %q, want application/cbor", gotContentType)

--- a/backend/maestro/maestro_test.go
+++ b/backend/maestro/maestro_test.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
 	"math"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
@@ -371,7 +373,7 @@ func TestEvaluateTxWithAdditionalUtxosPostsObjectShape(t *testing.T) {
 	}
 }
 
-func TestEvaluateTxEmptyAdditionalUtxosUsesSdkPath(t *testing.T) {
+func TestEvaluateTxEmptyAdditionalUtxosPostsSdkCompatibleShape(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
 		utxos []common.Utxo
@@ -404,11 +406,9 @@ func TestEvaluateTxEmptyAdditionalUtxosUsesSdkPath(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			// The SDK EvaluateTx posts to /transactions/evaluate as well, so the
-			// path alone does not distinguish the two code paths. The SDK body
-			// serializes additional_utxos from a nil []string, which encodes as
-			// JSON null; the raw object-shaped path would instead emit an array.
-			// Asserting null proves the empty/nil slice took the SDK fallback.
+			// Preserve the SDK-compatible request shape for no additional UTxOs:
+			// additional_utxos is null, while the object-shaped resolved-UTxO
+			// path emits an array.
 			if gotPath != "/transactions/evaluate" {
 				t.Fatalf("path = %q, want /transactions/evaluate", gotPath)
 			}
@@ -428,6 +428,118 @@ func TestEvaluateTxEmptyAdditionalUtxosUsesSdkPath(t *testing.T) {
 			spendKey := common.RedeemerKey{Tag: common.RedeemerTagSpend, Index: 0}
 			if eu := result[spendKey]; eu.Memory != 10 || eu.Steps != 20 {
 				t.Fatalf("unexpected spend budget %+v", eu)
+			}
+		})
+	}
+}
+
+func TestMaestroNetworkCallsUseRequestContext(t *testing.T) {
+	var txHash common.Blake2b256
+	addr := testAddress(t)
+	for _, tc := range []struct {
+		name   string
+		invoke func(context.Context, *MaestroChainContext) error
+	}{
+		{
+			name: "ProtocolParams",
+			invoke: func(ctx context.Context, m *MaestroChainContext) error {
+				_, err := m.ProtocolParams(ctx)
+				return err
+			},
+		},
+		{
+			name: "CurrentEpoch",
+			invoke: func(ctx context.Context, m *MaestroChainContext) error {
+				_, err := m.CurrentEpoch(ctx)
+				return err
+			},
+		},
+		{
+			name: "Tip",
+			invoke: func(ctx context.Context, m *MaestroChainContext) error {
+				_, err := m.Tip(ctx)
+				return err
+			},
+		},
+		{
+			name: "Utxos",
+			invoke: func(ctx context.Context, m *MaestroChainContext) error {
+				_, err := m.Utxos(ctx, addr)
+				return err
+			},
+		},
+		{
+			name: "SubmitTx",
+			invoke: func(ctx context.Context, m *MaestroChainContext) error {
+				_, err := m.SubmitTx(ctx, []byte{0x84})
+				return err
+			},
+		},
+		{
+			name: "EvaluateTx",
+			invoke: func(ctx context.Context, m *MaestroChainContext) error {
+				_, err := m.EvaluateTx(ctx, []byte{0x84}, nil)
+				return err
+			},
+		},
+		{
+			name: "UtxoByRef",
+			invoke: func(ctx context.Context, m *MaestroChainContext) error {
+				_, err := m.UtxoByRef(ctx, txHash, 0)
+				return err
+			},
+		},
+		{
+			name: "ScriptCbor",
+			invoke: func(ctx context.Context, m *MaestroChainContext) error {
+				_, err := m.ScriptCbor(ctx, common.Blake2b224{})
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			started := make(chan struct{})
+			release := make(chan struct{})
+			server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				close(started)
+				select {
+				case <-r.Context().Done():
+				case <-release:
+				}
+			}))
+			defer func() {
+				close(release)
+				server.Close()
+			}()
+
+			m, err := NewMaestroChainContextWithNetwork(0, "project-id", "preprod")
+			if err != nil {
+				t.Fatal(err)
+			}
+			m.client.BaseUrl = server.URL
+
+			ctx, cancel := context.WithCancel(context.Background())
+			errCh := make(chan error, 1)
+			go func() {
+				errCh <- tc.invoke(ctx, m)
+			}()
+
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				cancel()
+				t.Fatal("timed out waiting for Maestro request")
+			}
+
+			cancel()
+
+			select {
+			case err := <-errCh:
+				if !errors.Is(err, context.Canceled) {
+					t.Fatalf("expected context.Canceled, got %v", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for canceled Maestro request")
 			}
 		})
 	}

--- a/backend/ogmios/ogmios.go
+++ b/backend/ogmios/ogmios.go
@@ -40,8 +40,8 @@ func NewOgmiosChainContext(ogmiosClient *ogmigo.Client, kupoClient *kugo.Client,
 	}
 }
 
-func (o *OgmiosChainContext) ProtocolParams() (backend.ProtocolParameters, error) {
-	ctx := context.Background()
+func (o *OgmiosChainContext) ProtocolParams(ctx context.Context) (backend.ProtocolParameters, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	raw, err := o.ogmios.CurrentProtocolParameters(ctx)
 	if err != nil {
 		return backend.ProtocolParameters{}, err
@@ -55,8 +55,8 @@ func (o *OgmiosChainContext) ProtocolParams() (backend.ProtocolParameters, error
 	return params.toProtocolParams()
 }
 
-func (o *OgmiosChainContext) GenesisParams() (backend.GenesisParameters, error) {
-	ctx := context.Background()
+func (o *OgmiosChainContext) GenesisParams(ctx context.Context) (backend.GenesisParameters, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	raw, err := o.ogmios.GenesisConfig(ctx, "shelley")
 	if err != nil {
 		return backend.GenesisParameters{}, err
@@ -74,21 +74,22 @@ func (o *OgmiosChainContext) NetworkId() uint8 {
 	return o.networkId
 }
 
-func (o *OgmiosChainContext) CurrentEpoch() (uint64, error) {
-	ctx := context.Background()
+func (o *OgmiosChainContext) CurrentEpoch(ctx context.Context) (uint64, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	return o.ogmios.CurrentEpoch(ctx)
 }
 
-func (o *OgmiosChainContext) MaxTxFee() (uint64, error) {
-	pp, err := o.ProtocolParams()
+func (o *OgmiosChainContext) MaxTxFee(ctx context.Context) (uint64, error) {
+	ctx = backend.ContextOrBackground(ctx)
+	pp, err := o.ProtocolParams(ctx)
 	if err != nil {
 		return 0, err
 	}
 	return backend.ComputeMaxTxFee(pp)
 }
 
-func (o *OgmiosChainContext) Tip() (uint64, error) {
-	ctx := context.Background()
+func (o *OgmiosChainContext) Tip(ctx context.Context) (uint64, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	point, err := o.ogmios.ChainTip(ctx)
 	if err != nil {
 		return 0, err
@@ -100,11 +101,11 @@ func (o *OgmiosChainContext) Tip() (uint64, error) {
 	return ps.Slot, nil
 }
 
-func (o *OgmiosChainContext) Utxos(address common.Address) ([]common.Utxo, error) {
+func (o *OgmiosChainContext) Utxos(ctx context.Context, address common.Address) ([]common.Utxo, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	if o.kupo == nil {
 		return nil, errors.New("kupo client required for UTxO lookup")
 	}
-	ctx := context.Background()
 	matches, err := o.kupo.Matches(ctx, kugo.OnlyUnspent(), kugo.Address(address.String()))
 	if err != nil {
 		return nil, err
@@ -121,8 +122,8 @@ func (o *OgmiosChainContext) Utxos(address common.Address) ([]common.Utxo, error
 	return utxos, nil
 }
 
-func (o *OgmiosChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error) {
-	ctx := context.Background()
+func (o *OgmiosChainContext) SubmitTx(ctx context.Context, txCbor []byte) (common.Blake2b256, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	txHex := hex.EncodeToString(txCbor)
 	resp, err := o.ogmios.SubmitTx(ctx, txHex)
 	if err != nil {
@@ -143,8 +144,8 @@ func (o *OgmiosChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error) 
 	return result, nil
 }
 
-func (o *OgmiosChainContext) EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
-	ctx := context.Background()
+func (o *OgmiosChainContext) EvaluateTx(ctx context.Context, txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	txHex := hex.EncodeToString(txCbor)
 	var resp *ogmigo.EvaluateTxResponse
 	var err error
@@ -316,8 +317,8 @@ func evaluateResponseToExUnits(resp *ogmigo.EvaluateTxResponse) (map[common.Rede
 	return result, nil
 }
 
-func (o *OgmiosChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) (*common.Utxo, error) {
-	ctx := context.Background()
+func (o *OgmiosChainContext) UtxoByRef(ctx context.Context, txHash common.Blake2b256, index uint32) (*common.Utxo, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	hashHex := hex.EncodeToString(txHash.Bytes())
 	query := chainsync.TxInQuery{
 		Transaction: shared.UtxoTxID{ID: hashHex},
@@ -343,11 +344,11 @@ func (o *OgmiosChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) (
 	return &result, nil
 }
 
-func (o *OgmiosChainContext) ScriptCbor(scriptHash common.Blake2b224) ([]byte, error) {
+func (o *OgmiosChainContext) ScriptCbor(ctx context.Context, scriptHash common.Blake2b224) ([]byte, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	if o.kupo == nil {
 		return nil, errors.New("kupo client required for script lookup")
 	}
-	ctx := context.Background()
 	hashHex := hex.EncodeToString(scriptHash.Bytes())
 	script, err := o.kupo.Script(ctx, hashHex)
 	if err != nil {

--- a/backend/utxorpc/utxorpc.go
+++ b/backend/utxorpc/utxorpc.go
@@ -1,6 +1,7 @@
 package utxorpc
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -111,10 +112,11 @@ func bigIntToString(bi *cardano.BigInt) string {
 	}
 }
 
-func (u *UtxoRpcChainContext) ProtocolParams() (backend.ProtocolParameters, error) {
+func (u *UtxoRpcChainContext) ProtocolParams(ctx context.Context) (backend.ProtocolParameters, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	req := connect.NewRequest(&query.ReadParamsRequest{})
 	u.client.AddHeadersToRequest(req)
-	resp, err := u.client.ReadParams(req)
+	resp, err := u.client.ReadParamsWithContext(ctx, req)
 	if err != nil {
 		return backend.ProtocolParameters{}, err
 	}
@@ -202,7 +204,10 @@ func (u *UtxoRpcChainContext) ProtocolParams() (backend.ProtocolParameters, erro
 	return pp, nil
 }
 
-func (u *UtxoRpcChainContext) GenesisParams() (backend.GenesisParameters, error) {
+func (u *UtxoRpcChainContext) GenesisParams(ctx context.Context) (backend.GenesisParameters, error) {
+	if err := backend.ContextOrBackground(ctx).Err(); err != nil {
+		return backend.GenesisParameters{}, err
+	}
 	return backend.GenesisParameters{}, errors.New("genesis params not available via UTxO RPC")
 }
 
@@ -210,22 +215,27 @@ func (u *UtxoRpcChainContext) NetworkId() uint8 {
 	return u.networkId
 }
 
-func (u *UtxoRpcChainContext) CurrentEpoch() (uint64, error) {
+func (u *UtxoRpcChainContext) CurrentEpoch(ctx context.Context) (uint64, error) {
+	if err := backend.ContextOrBackground(ctx).Err(); err != nil {
+		return 0, err
+	}
 	return 0, errors.New("epoch query not available via UTxO RPC")
 }
 
-func (u *UtxoRpcChainContext) MaxTxFee() (uint64, error) {
-	pp, err := u.ProtocolParams()
+func (u *UtxoRpcChainContext) MaxTxFee(ctx context.Context) (uint64, error) {
+	ctx = backend.ContextOrBackground(ctx)
+	pp, err := u.ProtocolParams(ctx)
 	if err != nil {
 		return 0, err
 	}
 	return backend.ComputeMaxTxFee(pp)
 }
 
-func (u *UtxoRpcChainContext) Tip() (uint64, error) {
+func (u *UtxoRpcChainContext) Tip(ctx context.Context) (uint64, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	req := connect.NewRequest(&syncpb.ReadTipRequest{})
 	u.client.AddHeadersToRequest(req)
-	resp, err := u.client.ReadTip(req)
+	resp, err := u.client.ReadTipWithContext(ctx, req)
 	if err != nil {
 		return 0, err
 	}
@@ -236,7 +246,8 @@ func (u *UtxoRpcChainContext) Tip() (uint64, error) {
 	return tip.GetSlot(), nil
 }
 
-func (u *UtxoRpcChainContext) Utxos(address common.Address) ([]common.Utxo, error) {
+func (u *UtxoRpcChainContext) Utxos(ctx context.Context, address common.Address) ([]common.Utxo, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	addrBytes, err := address.Bytes()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get address bytes: %w", err)
@@ -256,7 +267,7 @@ func (u *UtxoRpcChainContext) Utxos(address common.Address) ([]common.Utxo, erro
 		},
 	})
 	u.client.AddHeadersToRequest(req)
-	resp, err := u.client.SearchUtxos(req)
+	resp, err := u.client.SearchUtxosWithContext(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -272,14 +283,15 @@ func (u *UtxoRpcChainContext) Utxos(address common.Address) ([]common.Utxo, erro
 	return utxos, nil
 }
 
-func (u *UtxoRpcChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error) {
+func (u *UtxoRpcChainContext) SubmitTx(ctx context.Context, txCbor []byte) (common.Blake2b256, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	req := connect.NewRequest(&submit.SubmitTxRequest{
 		Tx: &submit.AnyChainTx{
 			Type: &submit.AnyChainTx_Raw{Raw: txCbor},
 		},
 	})
 	u.client.AddHeadersToRequest(req)
-	resp, err := u.client.SubmitTx(req)
+	resp, err := u.client.SubmitTxWithContext(ctx, req)
 	if err != nil {
 		return common.Blake2b256{}, err
 	}
@@ -302,14 +314,15 @@ func (u *UtxoRpcChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error)
 // are already visible on-chain to the provider and does NOT support evaluating
 // off-chain or chained inputs. Passing a non-empty additionalUtxos is not an
 // error, but those UTxOs have no effect.
-func (u *UtxoRpcChainContext) EvaluateTx(txCbor []byte, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+func (u *UtxoRpcChainContext) EvaluateTx(ctx context.Context, txCbor []byte, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	req := connect.NewRequest(&submit.EvalTxRequest{
 		Tx: &submit.AnyChainTx{
 			Type: &submit.AnyChainTx_Raw{Raw: txCbor},
 		},
 	})
 	u.client.AddHeadersToRequest(req)
-	resp, err := u.client.EvalTx(req)
+	resp, err := u.client.EvalTxWithContext(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -362,7 +375,8 @@ func evalTxResponseToExUnits(msg *submit.EvalTxResponse) (map[common.RedeemerKey
 	return result, nil
 }
 
-func (u *UtxoRpcChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) (*common.Utxo, error) {
+func (u *UtxoRpcChainContext) UtxoByRef(ctx context.Context, txHash common.Blake2b256, index uint32) (*common.Utxo, error) {
+	ctx = backend.ContextOrBackground(ctx)
 	req := connect.NewRequest(&query.ReadUtxosRequest{
 		Keys: []*query.TxoRef{
 			{
@@ -372,7 +386,7 @@ func (u *UtxoRpcChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) 
 		},
 	})
 	u.client.AddHeadersToRequest(req)
-	resp, err := u.client.ReadUtxos(req)
+	resp, err := u.client.ReadUtxosWithContext(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -387,7 +401,10 @@ func (u *UtxoRpcChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) 
 	return &utxo, nil
 }
 
-func (u *UtxoRpcChainContext) ScriptCbor(_ common.Blake2b224) ([]byte, error) {
+func (u *UtxoRpcChainContext) ScriptCbor(ctx context.Context, _ common.Blake2b224) ([]byte, error) {
+	if err := backend.ContextOrBackground(ctx).Err(); err != nil {
+		return nil, err
+	}
 	return nil, errors.New("script lookup not available via UTxO RPC")
 }
 

--- a/docs/plutus_v3_support/cost_models.md
+++ b/docs/plutus_v3_support/cost_models.md
@@ -8,10 +8,11 @@ Cost models define the execution costs for each primitive operation in Plutus sc
 
 ## Cost Model Retrieval
 
-In Apollo v2, cost models are retrieved from the chain context via `ProtocolParams()`:
+In Apollo v2, cost models are retrieved from the chain context via
+`ProtocolParams(ctx)`:
 
 ```go
-pp, err := cc.ProtocolParams()
+pp, err := cc.ProtocolParams(ctx)
 if err != nil {
     // handle error
 }

--- a/docs/sundaeswap-fork-migration.md
+++ b/docs/sundaeswap-fork-migration.md
@@ -63,13 +63,12 @@ The following SundaeSwap fork APIs exist in upstream master with the
 | `RedeemerTagNames` | Was `RdeemerTagNames` in old upstream |
 | `Address.AddressFromBytes(payment, paymentIsScript, staking, stakingIsScript, network)` | Script credential support |
 | `Address.IsPublicKeyAddress() bool` | |
-| `ChainContext.Utxos() ([]UTxO.UTxO, error)` | Error return |
-| `ChainContext.EvaluateTx() (map[...]..., error)` | Error return |
-| `ChainContext.EvaluateTxWithAdditionalUtxos(...)` | |
-| `ChainContext.CostModelsV1/V2/V3()` | |
 | `PlutusData.CostModel` type | |
 | `Transaction.Bytes()` uses `CanonicalEncOptions` | |
 | `TransactionOutput.GetScriptRef()` returns `nil` for pre-Alonzo | |
+
+`ChainContext` methods are context-aware in v2; see [Context-Aware
+ChainContext Methods](#37-context-aware-chaincontext-methods).
 
 ---
 
@@ -195,28 +194,32 @@ key files, upstream handles the conversion automatically. If you were
 relying on the fork's raw-passthrough behavior with pre-expanded 64-byte
 keys, you may need to adjust.
 
-### 3.7 Additional Error Returns on ChainContext Methods
+### 3.7 Context-Aware ChainContext Methods
 
 Apollo v2 uses the `backend.ChainContext` interface from `backend/base.go`.
 Custom implementations must use these method names and signatures:
 
 ```go
-ProtocolParams() (backend.ProtocolParameters, error)
-GenesisParams() (backend.GenesisParameters, error)
+ProtocolParams(ctx context.Context) (backend.ProtocolParameters, error)
+GenesisParams(ctx context.Context) (backend.GenesisParameters, error)
 NetworkId() uint8
-CurrentEpoch() (uint64, error)
-MaxTxFee() (uint64, error)
-Tip() (uint64, error)
-Utxos(address common.Address) ([]common.Utxo, error)
-SubmitTx(txCbor []byte) (common.Blake2b256, error)
-EvaluateTx(txCbor []byte) (map[common.RedeemerKey]common.ExUnits, error)
-UtxoByRef(txHash common.Blake2b256, index uint32) (*common.Utxo, error)
-ScriptCbor(scriptHash common.Blake2b224) ([]byte, error)
+CurrentEpoch(ctx context.Context) (uint64, error)
+MaxTxFee(ctx context.Context) (uint64, error)
+Tip(ctx context.Context) (uint64, error)
+Utxos(ctx context.Context, address common.Address) ([]common.Utxo, error)
+SubmitTx(ctx context.Context, txCbor []byte) (common.Blake2b256, error)
+EvaluateTx(ctx context.Context, txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error)
+UtxoByRef(ctx context.Context, txHash common.Blake2b256, index uint32) (*common.Utxo, error)
+ScriptCbor(ctx context.Context, scriptHash common.Blake2b224) ([]byte, error)
 ```
 
 **Migration:** Rename old fork methods such as `GetProtocolParams`,
 `GetGenesisParams`, `Epoch`, `LastBlockSlot`, and `GetContractCbor` to the
-v2 interface above, and update integer return types where needed.
+v2 interface above, pass `context.Context` to backend calls, and update integer
+return types where needed. Apollo's `Complete()`, `Submit()`, and
+`UtxoFromRef(...)` remain context-free convenience wrappers; use
+`CompleteContext(ctx)`, `SubmitContext(ctx)`, and `UtxoFromRefContext(ctx, ...)`
+when cancellation or deadlines matter.
 
 ### 3.8 `ProtocolParameters.MinFeeReferenceScripts`
 
@@ -265,8 +268,9 @@ Run `go mod tidy` after switching imports.
    `AddReferenceInput(txHash, index).AddReferenceScriptV1/V2/V3()`
 3. **Update** `UtxoFromRef` / `GetUtxoFromRef` callers to expect
    `*UTxO.UTxO` instead of `UTxO.UTxO`
-4. **Update** any custom `ChainContext` implementations to match the
-   v2 `backend.ChainContext` interface (`ProtocolParams`, `GenesisParams`,
+4. **Update** any custom `ChainContext` implementations to accept
+   `context.Context` and match the v2 `backend.ChainContext` interface
+   (`ProtocolParams`, `GenesisParams`,
    `NetworkId`, `CurrentEpoch`, `MaxTxFee`, `Tip`, `Utxos`, `SubmitTx`,
    `EvaluateTx`, `UtxoByRef`, `ScriptCbor`)
 5. **Replace** `ScriptRef` struct usage with the new `[]byte`-based

--- a/docs/v2_migration/MIGRATION.md
+++ b/docs/v2_migration/MIGRATION.md
@@ -307,6 +307,22 @@ import "github.com/Salvionied/apollo/v2/backend"
 
 Supported backends: `blockfrost`, `ogmios`, `maestro`, `utxorpc`, `fixed` (testing).
 
+Methods that can block or call the network now accept `context.Context`:
+`ProtocolParams`, `GenesisParams`, `CurrentEpoch`, `MaxTxFee`, `Tip`, `Utxos`,
+`SubmitTx`, `EvaluateTx`, `UtxoByRef`, and `ScriptCbor`. `NetworkId` remains
+context-free.
+
+```go
+pp, err := cc.ProtocolParams(ctx)
+utxos, err := cc.Utxos(ctx, addr)
+eval, err := cc.EvaluateTx(ctx, txCbor, additionalUtxos)
+```
+
+Apollo keeps the existing `Complete()`, `Submit()`, and `UtxoFromRef(...)`
+methods as `context.Background()` wrappers. Use `CompleteContext(ctx)`,
+`SubmitContext(ctx)`, and `UtxoFromRefContext(ctx, ...)` when callers need
+cancellation or deadlines.
+
 ### 13. Value Type
 
 v2 introduces an explicit `Value` type replacing various ad-hoc representations:
@@ -392,6 +408,7 @@ a, err = a.SetWalletFromMnemonicWithPassphrase(mnemonic, "pass")  // with passph
 - `CollectFrom(utxo, redeemer, exUnits) *Apollo`
 - `ConsumeUTxO(utxo, payments...) (*Apollo, error)`
 - `UtxoFromRef(hash, index) (*Utxo, error)`
+- `UtxoFromRefContext(ctx, hash, index) (*Utxo, error)`
 - `GetUsedUTxOs() []string`
 
 ### Scripts & Minting
@@ -456,10 +473,12 @@ a, err = a.SetWalletFromMnemonicWithPassphrase(mnemonic, "pass")  // with passph
 
 ### Building & Signing
 - `Complete() (*Apollo, error)`
+- `CompleteContext(ctx) (*Apollo, error)`
 - `Sign() (*Apollo, error)`
 - `SignWithSkey(skey) (*Apollo, error)`
 - `AddVerificationKeyWitness(witness) (*Apollo, error)`
 - `Submit() (Blake2b256, error)`
+- `SubmitContext(ctx) (Blake2b256, error)`
 - `GetTx() *ConwayTransaction`
 - `GetTxCbor() ([]byte, error)`
 - `LoadTxCbor(hex) (*Apollo, error)`

--- a/models.go
+++ b/models.go
@@ -1,6 +1,7 @@
 package apollo
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"math"
@@ -100,7 +101,7 @@ func (u *Unit) toMintValue() (Value, error) {
 
 // PaymentI is the interface for payment types.
 type PaymentI interface {
-	EnsureMinUTXO(cc backend.ChainContext) error
+	EnsureMinUTXO(ctx context.Context, cc backend.ChainContext) error
 	ToTxOut() (*babbage.BabbageTransactionOutput, error)
 	ToValue() (Value, error)
 }
@@ -223,11 +224,12 @@ func (p *Payment) ToValue() (Value, error) {
 // EnsureMinUTXO ensures the payment meets the minimum UTxO requirement.
 // It iterates because raising Lovelace can increase the CBOR-encoded output size,
 // which in turn may require a slightly higher min UTxO. Converges in 1-2 iterations.
-func (p *Payment) EnsureMinUTXO(cc backend.ChainContext) error {
+func (p *Payment) EnsureMinUTXO(ctx context.Context, cc backend.ChainContext) error {
 	if len(p.Units) == 0 && p.Lovelace >= constants.MinLovelace && p.Datum == nil && len(p.DatumHash) == 0 && p.ScriptRef == nil {
 		return nil
 	}
-	pp, err := cc.ProtocolParams()
+	ctx = backend.ContextOrBackground(ctx)
+	pp, err := cc.ProtocolParams(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get protocol params: %w", err)
 	}

--- a/readme.md
+++ b/readme.md
@@ -2,13 +2,18 @@
     <img src="./assets/logo.jpg" alt="apollo logo" width="480">
 </div>
 
-# Apollo: Pure Golang Cardano Building blocks 
+# Apollo: Pure Golang Cardano Building Blocks
 ## Pure Golang Cardano Serialization
 
-The Objective of this library is to give Developers Access to each and every needed resource for cardano development.
-The final goal is to be able to have this library interact directly with the node without intermediaries.
+Apollo is a Go library for building Cardano transactions with native ledger
+types from Blink Labs packages.
 
-Little Sample Usage:
+## Quickstart
+
+This example builds, signs, serializes, and submits a simple ADA payment. Replace
+the mnemonic, receiver address, and Blockfrost project ID with real values before
+running it.
+
 ```go
 package main
 
@@ -23,29 +28,33 @@ import (
 )
 
 func main() {
+    // ChainContext supplies protocol parameters, UTxOs, evaluation, and submit.
     bfc := blockfrost.NewBlockFrostChainContext(
         "https://cardano-mainnet.blockfrost.io/api/v0",
         1,
-        "your_blockfrost_project_id",
+        "mainnet0123456789abcdef0123456789abcdef",
     )
 
-    mnemonic := "your mnemonic here"
+    mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
     a := apollo.New(bfc)
-    a, err = a.SetWalletFromMnemonic(mnemonic)
+    a, err := a.SetWalletFromMnemonic(mnemonic)
     if err != nil {
         panic(err)
     }
 
+    // Query spendable UTxOs for the wallet address.
     utxos, err := bfc.Utxos(a.GetWallet().Address())
     if err != nil {
         panic(err)
     }
 
-    receiver, err := common.NewAddress("addr1...")
+    receiver, err := common.NewAddress("addr1vxp5xez7t3dvr4s8fr3m4yqdhury9m35g3c9d53j8s5tncgphe3d9")
     if err != nil {
         panic(err)
     }
 
+    // AddLoadedUTxOs provides candidate inputs; PayToAddress adds an output.
+    // Complete selects inputs, balances change, calculates fees, and builds the tx.
     a, err = a.AddLoadedUTxOs(utxos...).
         PayToAddress(receiver, 1_000_000).
         Complete()
@@ -53,17 +62,20 @@ func main() {
         panic(err)
     }
 
+    // Sign adds the wallet's verification-key witness.
     a, err = a.Sign()
     if err != nil {
         panic(err)
     }
 
+    // CBOR is the binary transaction format submitted to the network.
     txCbor, err := a.GetTxCbor()
     if err != nil {
         panic(err)
     }
     fmt.Println(hex.EncodeToString(txCbor))
 
+    // Submit sends the signed transaction through the ChainContext backend.
     txId, err := a.Submit()
     if err != nil {
         panic(err)
@@ -71,6 +83,11 @@ func main() {
     fmt.Println(hex.EncodeToString(txId.Bytes()))
 }
 ```
+
+More examples and feature docs are in [docs/README.md](docs/README.md). If you
+are migrating from Apollo v1, start with
+[docs/v2_migration/MIGRATION.md](docs/v2_migration/MIGRATION.md).
+
 ## Coin Selection
 
 Apollo selects transaction inputs with **MACS** (Multi-Asset Coin Selection,

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@ running it.
 package main
 
 import (
+    "context"
     "encoding/hex"
     "fmt"
 
@@ -28,6 +29,8 @@ import (
 )
 
 func main() {
+    ctx := context.Background()
+
     // ChainContext supplies protocol parameters, UTxOs, evaluation, and submit.
     bfc := blockfrost.NewBlockFrostChainContext(
         "https://cardano-mainnet.blockfrost.io/api/v0",
@@ -43,7 +46,7 @@ func main() {
     }
 
     // Query spendable UTxOs for the wallet address.
-    utxos, err := bfc.Utxos(a.GetWallet().Address())
+    utxos, err := bfc.Utxos(ctx, a.GetWallet().Address())
     if err != nil {
         panic(err)
     }
@@ -54,10 +57,10 @@ func main() {
     }
 
     // AddLoadedUTxOs provides candidate inputs; PayToAddress adds an output.
-    // Complete selects inputs, balances change, calculates fees, and builds the tx.
+    // CompleteContext selects inputs, balances change, calculates fees, and builds the tx.
     a, err = a.AddLoadedUTxOs(utxos...).
         PayToAddress(receiver, 1_000_000).
-        Complete()
+        CompleteContext(ctx)
     if err != nil {
         panic(err)
     }
@@ -75,8 +78,8 @@ func main() {
     }
     fmt.Println(hex.EncodeToString(txCbor))
 
-    // Submit sends the signed transaction through the ChainContext backend.
-    txId, err := a.Submit()
+    // SubmitContext sends the signed transaction through the ChainContext backend.
+    txId, err := a.SubmitContext(ctx)
     if err != nil {
         panic(err)
     }

--- a/security_hardening_test.go
+++ b/security_hardening_test.go
@@ -1,6 +1,7 @@
 package apollo
 
 import (
+	"context"
 	"crypto/ed25519"
 	"fmt"
 	"math"
@@ -288,7 +289,7 @@ type fakeEvalContext struct {
 	result map[common.RedeemerKey]common.ExUnits
 }
 
-func (f *fakeEvalContext) EvaluateTx(_ []byte, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+func (f *fakeEvalContext) EvaluateTx(_ context.Context, _ []byte, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
 	return f.result, nil
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds context propagation across Apollo and all backends to support cancellation and deadlines without changing default behavior. New context-aware methods are added; existing APIs remain as background wrappers.

- **Refactors**
  - `backend.ChainContext` methods now take `context.Context`: `ProtocolParams`, `GenesisParams`, `CurrentEpoch`, `MaxTxFee`, `Tip`, `Utxos`, `SubmitTx`, `EvaluateTx(ctx, txCbor, additionalUtxos)`, `UtxoByRef`, `ScriptCbor` (only `NetworkId` is unchanged). Added `backend.ContextOrBackground`.
  - Backends updated: `blockfrost`, `ogmios`, `maestro`, `utxorpc`, and `fixed`; all HTTP/gRPC requests use the caller’s context. `maestro` now issues raw context-aware HTTP requests (Submit posts CBOR to `/txmanager` with `Accept: text/plain`; Evaluate posts JSON to `/transactions/evaluate`, emitting object-shaped `additional_utxos` when provided and `null` when empty).
  - Apollo adds `CompleteContext(ctx)`, `SubmitContext(ctx)`, and `UtxoFromRefContext(ctx, ...)`. Internal helpers propagate `ctx`. `Payment.EnsureMinUTXO` now requires `ctx`.
  - Cache layer passes contexts through and preserves TTL. Tests cover cancellation and context propagation across backends. Docs and README quickstart updated for context usage.

- **Migration**
  - Update calls from `cc.Method()` to `cc.Method(ctx)` across the methods above; `EvaluateTx` now also accepts `additionalUtxos`.
  - Use Apollo’s `CompleteContext`, `SubmitContext`, and `UtxoFromRefContext` when you need cancellation; `Complete`, `Submit`, and `UtxoFromRef` remain `context.Background()` wrappers.
  - If you implement custom payments, change `EnsureMinUTXO(cc)` to `EnsureMinUTXO(ctx, cc)`.

<sup>Written for commit 9e995ee7315318b53b63a25e7f65b5c24a0946f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/salvionied-apollo/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

