### PR TITLE
feat: build report and explain API

### DIFF
--- a/apollo.go
+++ b/apollo.go
@@ -38,6 +38,7 @@ type Apollo struct {
 	preselectedUtxos   []common.Utxo
 	inputAddresses     []common.Address
 	tx                 *conway.ConwayTransaction
+	buildReport        *BuildReport
 	datums             []common.Datum
 	requiredSigners    []common.Blake2b224
 	v1scripts          []common.PlutusV1Script
@@ -936,6 +937,7 @@ func (a *Apollo) LoadTxCbor(txCbor string) (*Apollo, error) {
 		return a, fmt.Errorf("failed to decode transaction: %w", err)
 	}
 	a.tx = &tx
+	a.buildReport = nil
 	return a, nil
 }
 
@@ -1029,6 +1031,9 @@ func (a *Apollo) Clone() *Apollo {
 			}
 		}
 	}
+	if a.buildReport != nil {
+		clone.buildReport = a.buildReport.clone()
+	}
 	return clone
 }
 
@@ -1072,6 +1077,17 @@ func (a *Apollo) GetWallet() Wallet {
 	return a.wallet
 }
 
+// Explain returns a diagnostic report for the transaction built by Complete.
+func (a *Apollo) Explain() (*BuildReport, error) {
+	if a.tx == nil {
+		return nil, errors.New("transaction not built - call Complete() first")
+	}
+	if a.buildReport == nil {
+		return nil, errors.New("no build report available for this transaction")
+	}
+	return a.buildReport.clone(), nil
+}
+
 // Complete performs coin selection, fee estimation, and builds the transaction.
 func (a *Apollo) Complete() (*Apollo, error) {
 	return a.CompleteContext(context.Background())
@@ -1089,10 +1105,21 @@ func (a *Apollo) CompleteContext(ctx context.Context) (*Apollo, error) {
 	if a.wallet == nil {
 		return a, errors.New("wallet is required to complete transaction")
 	}
+	a.buildReport = nil
 
 	// Load UTxOs from input addresses if needed (must happen before collateral selection)
 	if err := a.loadUtxos(ctx); err != nil {
 		return a, err
+	}
+
+	reportParams, err := a.Context.ProtocolParams(ctx)
+	if err != nil {
+		return a, fmt.Errorf("failed to get protocol params for build report: %w", err)
+	}
+	reportCoinsPerUtxoByte := reportParams.CoinsPerUtxoByteValue()
+	requestedOutputs, err := a.requestedOutputReports(reportCoinsPerUtxoByte)
+	if err != nil {
+		return a, fmt.Errorf("failed to build requested output report: %w", err)
 	}
 
 	// Auto-select collateral if needed (after UTxOs are loaded)
@@ -1264,6 +1291,10 @@ func (a *Apollo) CompleteContext(ctx context.Context) (*Apollo, error) {
 	const maxFeeIterations = 3
 	baseOutputs := make([]babbage.BabbageTransactionOutput, len(outputs))
 	copy(baseOutputs, outputs)
+	baseOutputReports, err := outputReportsFromTxOuts(baseOutputs, -1, reportCoinsPerUtxoByte, requestedOutputs)
+	if err != nil {
+		return a, fmt.Errorf("failed to build base output report: %w", err)
+	}
 
 	var fee int64
 	if a.forceFee {
@@ -1451,6 +1482,49 @@ func (a *Apollo) CompleteContext(ctx context.Context) (*Apollo, error) {
 		return a, err
 	}
 
+	changeOutputIndex := -1
+	if len(outputs) > len(baseOutputs) {
+		changeOutputIndex = len(baseOutputs)
+	}
+	finalOutputReports, err := outputReportsFromTxOuts(outputs, changeOutputIndex, reportCoinsPerUtxoByte, requestedOutputs)
+	if err != nil {
+		return a, fmt.Errorf("failed to build final output report: %w", err)
+	}
+	totalOutput, err := a.totalOutputValue(outputs)
+	if err != nil {
+		return a, err
+	}
+	refScriptSize, err := a.totalReferenceScriptSize(ctx, allInputUtxos)
+	if err != nil {
+		return a, err
+	}
+	refScriptFee, err := referenceScriptFeeForSize(refScriptSize, reportParams)
+	if err != nil {
+		return a, err
+	}
+	redeemerReports := a.redeemerReports(allInputUtxos)
+	executionUnits := totalRedeemerExUnits(redeemerReports)
+	executionUnitFee, err := executionUnitFee(reportParams, executionUnits)
+	if err != nil {
+		return a, err
+	}
+	mintValue, err := a.mintValue()
+	if err != nil {
+		return a, err
+	}
+	burnValue, err := a.burnRequirementValue()
+	if err != nil {
+		return a, err
+	}
+	requiredCollateral, err := collateralRequired(fee, reportParams.CollateralPercent)
+	if err != nil {
+		return a, err
+	}
+	collateralReturnReport, err := outputReportPtr(a.collateralReturn, 0, false, reportCoinsPerUtxoByte)
+	if err != nil {
+		return a, fmt.Errorf("failed to build collateral return report: %w", err)
+	}
+
 	// Build transaction body
 	body, err := a.buildBody(ctx, allInputUtxos, outputs, uint64(fee))
 	if err != nil {
@@ -1477,6 +1551,42 @@ func (a *Apollo) CompleteContext(ctx context.Context) (*Apollo, error) {
 			a.tx.TxMetadata = md
 		}
 	}
+
+	report, err := a.newBuildReport(buildReportSnapshot{
+		requestedOutputs:        requestedOutputs,
+		baseOutputReports:       baseOutputReports,
+		finalOutputReports:      finalOutputReports,
+		preselectedUtxos:        a.preselectedUtxos,
+		selectedUtxos:           selectedUtxos,
+		finalInputUtxos:         allInputUtxos,
+		selectionTarget:         selectionTarget,
+		totalInput:              totalInput,
+		totalRequired:           totalRequired,
+		governanceRequired:      governanceRequired,
+		refundValue:             refundValue,
+		stakeDeposit:            stakeDeposit,
+		preliminaryFee:          prelimFee,
+		refScriptFeeReserve:     refScriptFeeReserve,
+		refScriptSize:           refScriptSize,
+		refScriptFee:            refScriptFee,
+		executionUnits:          executionUnits,
+		executionUnitFee:        executionUnitFee,
+		feeSizeComponent:        feeSizeComponent(fee, a.FeePadding, refScriptFee, executionUnitFee),
+		finalFee:                fee,
+		collateralRequired:      requiredCollateral,
+		collateralReturn:        collateralReturnReport,
+		redeemers:               redeemerReports,
+		mintValue:               mintValue,
+		burnValue:               burnValue,
+		totalOutput:             totalOutput,
+		collateralAutoSelected:  a.collateralAutoSelected,
+		collateralOverlapRef:    a.collateralOverlapRef,
+		changeOutputIndexOffset: len(baseOutputs),
+	})
+	if err != nil {
+		return a, fmt.Errorf("failed to build transaction report: %w", err)
+	}
+	a.buildReport = report
 
 	return a, nil
 }

--- a/build_report.go
+++ b/build_report.go
@@ -1,0 +1,552 @@
+package apollo
+
+import (
+	"encoding/hex"
+	"errors"
+	"math"
+	"sort"
+	"strconv"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+
+	"github.com/Salvionied/apollo/v2/backend"
+)
+
+// BuildReport explains the transaction assembled by Complete or CompleteContext.
+type BuildReport struct {
+	TxHash       string
+	TxSize       int
+	CoinSelector string
+	Inputs       InputReport
+	Outputs      OutputReport
+	Fees         FeeReport
+	Balance      BalanceReport
+	Collateral   CollateralReport
+	Redeemers    []RedeemerReport
+	Scripts      ScriptReport
+}
+
+// InputReport summarizes how transaction inputs were chosen.
+type InputReport struct {
+	InputAddresses     []string
+	AvailableUtxoCount int
+	Preselected        []UtxoReport
+	Selected           []UtxoReport
+	Final              []UtxoReport
+	SelectionTarget    Value
+}
+
+// UtxoReport summarizes a resolved UTxO used while building a transaction.
+type UtxoReport struct {
+	Ref     string
+	Address string
+	Value   Value
+}
+
+// OutputReport summarizes requested, base, final, and change outputs.
+type OutputReport struct {
+	Requested   []TxOutputReport
+	Base        []TxOutputReport
+	Final       []TxOutputReport
+	ChangeIndex int
+	Change      Value
+}
+
+// TxOutputReport summarizes a transaction output without exposing ledger internals.
+type TxOutputReport struct {
+	Index           int
+	Address         string
+	Value           Value
+	IsChange        bool
+	MinLovelace     int64
+	MinUtxoIncrease uint64
+	HasInlineDatum  bool
+	HasDatumHash    bool
+	HasScriptRef    bool
+}
+
+// FeeReport summarizes fee inputs used by the builder.
+type FeeReport struct {
+	Final                  int64
+	Size                   int64
+	Padding                int64
+	Forced                 bool
+	Preliminary            int64
+	ReferenceScriptReserve int64
+	ReferenceScriptBytes   int
+	ReferenceScriptFee     int64
+	ExecutionUnits         common.ExUnits
+	ExecutionUnitFee       int64
+}
+
+// BalanceReport summarizes the high-level Cardano balance equation components.
+type BalanceReport struct {
+	TotalInput         Value
+	TotalRequired      Value
+	TotalOutput        Value
+	Change             Value
+	Fee                int64
+	Withdrawals        Value
+	Mint               Value
+	Burn               Value
+	CertificateDeposit int64
+	CertificateRefund  Value
+	GovernanceRequired Value
+	ProposalDeposit    uint64
+	TreasuryDonation   uint64
+}
+
+// CollateralReport summarizes collateral inputs and return output.
+type CollateralReport struct {
+	Inputs       []UtxoReport
+	Required     int64
+	Total        int64
+	Return       *TxOutputReport
+	AutoSelected bool
+	OverlapRef   string
+}
+
+// RedeemerReport summarizes a redeemer after final canonical indexing.
+type RedeemerReport struct {
+	Tag     common.RedeemerTag
+	Index   uint32
+	Source  string
+	ExUnits common.ExUnits
+}
+
+// ScriptReport summarizes attached scripts and script-related transaction data.
+type ScriptReport struct {
+	PlutusV1           int
+	PlutusV2           int
+	PlutusV3           int
+	Native             int
+	Datums             int
+	ReferenceInputs    int
+	RequiredSigners    int
+	ReferenceInputRefs []string
+	ScriptHashes       []string
+	RequiredSignerKeys []string
+}
+
+type buildReportSnapshot struct {
+	requestedOutputs        []TxOutputReport
+	baseOutputReports       []TxOutputReport
+	finalOutputReports      []TxOutputReport
+	preselectedUtxos        []common.Utxo
+	selectedUtxos           []common.Utxo
+	finalInputUtxos         []common.Utxo
+	selectionTarget         Value
+	totalInput              Value
+	totalRequired           Value
+	governanceRequired      Value
+	refundValue             Value
+	stakeDeposit            int64
+	preliminaryFee          int64
+	refScriptFeeReserve     int64
+	refScriptSize           int
+	refScriptFee            int64
+	executionUnits          common.ExUnits
+	executionUnitFee        int64
+	feeSizeComponent        int64
+	finalFee                int64
+	collateralRequired      int64
+	collateralReturn        *TxOutputReport
+	redeemers               []RedeemerReport
+	mintValue               Value
+	burnValue               Value
+	totalOutput             Value
+	collateralAutoSelected  bool
+	collateralOverlapRef    string
+	changeOutputIndexOffset int
+}
+
+func (a *Apollo) newBuildReport(snapshot buildReportSnapshot) (*BuildReport, error) {
+	if a.tx == nil {
+		return nil, errors.New("transaction not built")
+	}
+	bodyCbor, err := cbor.Encode(&a.tx.Body)
+	if err != nil {
+		return nil, err
+	}
+	txCbor, err := cbor.Encode(a.tx)
+	if err != nil {
+		return nil, err
+	}
+	txHash := common.Blake2b256Hash(bodyCbor)
+
+	redeemers := append([]RedeemerReport(nil), snapshot.redeemers...)
+	depositAdjustment := a.certificateDepositAdjustment(snapshot.stakeDeposit)
+	certificateDeposit := int64(0)
+	if depositAdjustment > 0 {
+		certificateDeposit = depositAdjustment
+	}
+
+	return &BuildReport{
+		TxHash:       hex.EncodeToString(txHash.Bytes()),
+		TxSize:       len(txCbor),
+		CoinSelector: a.coinSelectorName(),
+		Inputs: InputReport{
+			InputAddresses:     addressStrings(a.inputAddresses),
+			AvailableUtxoCount: len(a.utxos),
+			Preselected:        utxoReportsFromUtxos(snapshot.preselectedUtxos),
+			Selected:           utxoReportsFromUtxos(snapshot.selectedUtxos),
+			Final:              utxoReportsFromUtxos(snapshot.finalInputUtxos),
+			SelectionTarget:    snapshot.selectionTarget.Clone(),
+		},
+		Outputs: OutputReport{
+			Requested:   cloneTxOutputReports(snapshot.requestedOutputs),
+			Base:        cloneTxOutputReports(snapshot.baseOutputReports),
+			Final:       cloneTxOutputReports(snapshot.finalOutputReports),
+			ChangeIndex: snapshot.changeOutputIndex(),
+			Change:      changeValueFromReports(snapshot.finalOutputReports, snapshot.changeOutputIndex()),
+		},
+		Fees: FeeReport{
+			Final:                  snapshot.finalFee,
+			Size:                   snapshot.feeSizeComponent,
+			Padding:                a.FeePadding,
+			Forced:                 a.forceFee || a.Fee > 0,
+			Preliminary:            snapshot.preliminaryFee,
+			ReferenceScriptReserve: snapshot.refScriptFeeReserve,
+			ReferenceScriptBytes:   snapshot.refScriptSize,
+			ReferenceScriptFee:     snapshot.refScriptFee,
+			ExecutionUnits:         snapshot.executionUnits,
+			ExecutionUnitFee:       snapshot.executionUnitFee,
+		},
+		Balance: BalanceReport{
+			TotalInput:         snapshot.totalInput.Clone(),
+			TotalRequired:      snapshot.totalRequired.Clone(),
+			TotalOutput:        snapshot.totalOutput.Clone(),
+			Change:             changeValueFromReports(snapshot.finalOutputReports, snapshot.changeOutputIndex()),
+			Fee:                snapshot.finalFee,
+			Withdrawals:        a.totalWithdrawalValue().Clone(),
+			Mint:               snapshot.mintValue.Clone(),
+			Burn:               snapshot.burnValue.Clone(),
+			CertificateDeposit: certificateDeposit,
+			CertificateRefund:  snapshot.refundValue.Clone(),
+			GovernanceRequired: snapshot.governanceRequired.Clone(),
+			ProposalDeposit:    a.proposalDepositTotal(),
+			TreasuryDonation:   uint64(a.treasuryDonation), //nolint:gosec // validated non-negative by AddTreasuryDonation
+		},
+		Collateral: CollateralReport{
+			Inputs:       utxoReportsFromUtxos(a.collaterals),
+			Required:     snapshot.collateralRequired,
+			Total:        a.totalCollateral,
+			Return:       cloneTxOutputReportPtr(snapshot.collateralReturn),
+			AutoSelected: snapshot.collateralAutoSelected,
+			OverlapRef:   snapshot.collateralOverlapRef,
+		},
+		Redeemers: redeemers,
+		Scripts: ScriptReport{
+			PlutusV1:           len(a.v1scripts),
+			PlutusV2:           len(a.v2scripts),
+			PlutusV3:           len(a.v3scripts),
+			Native:             len(a.nativescripts),
+			Datums:             len(a.datums),
+			ReferenceInputs:    len(a.referenceInputs),
+			RequiredSigners:    len(a.requiredSigners),
+			ReferenceInputRefs: referenceInputRefs(a.referenceInputs),
+			ScriptHashes:       append([]string(nil), a.scriptHashes...),
+			RequiredSignerKeys: requiredSignerKeys(a.requiredSigners),
+		},
+	}, nil
+}
+
+func (s buildReportSnapshot) changeOutputIndex() int {
+	if len(s.finalOutputReports) > s.changeOutputIndexOffset {
+		return s.changeOutputIndexOffset
+	}
+	return -1
+}
+
+func (a *Apollo) requestedOutputReports(coinsPerUtxoByte int64) ([]TxOutputReport, error) {
+	reports := make([]TxOutputReport, 0, len(a.payments))
+	for i, payment := range a.payments {
+		txOut, err := payment.ToTxOut()
+		if err != nil {
+			return nil, err
+		}
+		report, err := outputReportFromTxOut(i, *txOut, false, coinsPerUtxoByte)
+		if err != nil {
+			return nil, err
+		}
+		reports = append(reports, report)
+	}
+	return reports, nil
+}
+
+func (a *Apollo) coinSelectorName() string {
+	if a.coinSelector != nil {
+		return a.coinSelector.Name()
+	}
+	return defaultCoinSelector.Name()
+}
+
+func (a *Apollo) redeemerReports(inputs []common.Utxo) []RedeemerReport {
+	redeemerMap := a.buildRedeemerMap(inputs)
+	reports := make([]RedeemerReport, 0, len(redeemerMap))
+	for key, value := range redeemerMap {
+		reports = append(reports, RedeemerReport{
+			Tag:     key.Tag,
+			Index:   key.Index,
+			Source:  a.redeemerSource(key, inputs),
+			ExUnits: value.ExUnits,
+		})
+	}
+	sortRedeemerReports(reports)
+	return reports
+}
+
+func (a *Apollo) redeemerSource(key common.RedeemerKey, inputs []common.Utxo) string {
+	switch key.Tag {
+	case common.RedeemerTagSpend:
+		if int(key.Index) < len(inputs) {
+			return utxoRef(inputs[key.Index])
+		}
+	case common.RedeemerTagMint:
+		policies := a.sortedMintPolicyIds()
+		if int(key.Index) < len(policies) {
+			return policies[key.Index]
+		}
+	case common.RedeemerTagReward:
+		keys := a.sortedWithdrawalKeys()
+		if int(key.Index) < len(keys) {
+			return keys[key.Index]
+		}
+	}
+	return ""
+}
+
+func outputReportsFromTxOuts(
+	outputs []babbage.BabbageTransactionOutput,
+	changeIndex int,
+	coinsPerUtxoByte int64,
+	requested []TxOutputReport,
+) ([]TxOutputReport, error) {
+	reports := make([]TxOutputReport, 0, len(outputs))
+	for i, output := range outputs {
+		report, err := outputReportFromTxOut(i, output, i == changeIndex, coinsPerUtxoByte)
+		if err != nil {
+			return nil, err
+		}
+		if i < len(requested) && report.Value.Coin > requested[i].Value.Coin {
+			report.MinUtxoIncrease = report.Value.Coin - requested[i].Value.Coin
+		}
+		reports = append(reports, report)
+	}
+	return reports, nil
+}
+
+func outputReportPtr(output *babbage.BabbageTransactionOutput, index int, isChange bool, coinsPerUtxoByte int64) (*TxOutputReport, error) {
+	if output == nil {
+		return nil, nil
+	}
+	report, err := outputReportFromTxOut(index, *output, isChange, coinsPerUtxoByte)
+	if err != nil {
+		return nil, err
+	}
+	return &report, nil
+}
+
+func outputReportFromTxOut(index int, output babbage.BabbageTransactionOutput, isChange bool, coinsPerUtxoByte int64) (TxOutputReport, error) {
+	minLovelace, err := MinLovelacePostAlonzo(&output, coinsPerUtxoByte)
+	if err != nil {
+		return TxOutputReport{}, err
+	}
+	report := TxOutputReport{
+		Index:          index,
+		Address:        output.OutputAddress.String(),
+		Value:          ValueFromMaryValue(output.OutputAmount),
+		IsChange:       isChange,
+		MinLovelace:    minLovelace,
+		HasInlineDatum: output.Datum() != nil,
+		HasDatumHash:   output.DatumHash() != nil,
+		HasScriptRef:   output.ScriptRef() != nil,
+	}
+	if minLovelace > 0 && report.Value.Coin < uint64(minLovelace) {
+		report.MinUtxoIncrease = uint64(minLovelace) - report.Value.Coin //nolint:gosec // minLovelace > 0
+	}
+	return report, nil
+}
+
+func utxoReportsFromUtxos(utxos []common.Utxo) []UtxoReport {
+	reports := make([]UtxoReport, 0, len(utxos))
+	for _, utxo := range utxos {
+		reports = append(reports, utxoReportFromUtxo(utxo))
+	}
+	return reports
+}
+
+func utxoReportFromUtxo(utxo common.Utxo) UtxoReport {
+	report := UtxoReport{Ref: utxoRef(utxo)}
+	if utxo.Output == nil {
+		return report
+	}
+	report.Address = utxo.Output.Address().String()
+	amount := utxo.Output.Amount()
+	if amount != nil && amount.IsUint64() {
+		report.Value.Coin = amount.Uint64()
+	}
+	report.Value.Assets = CloneMultiAsset(utxo.Output.Assets())
+	return report
+}
+
+func changeValueFromReports(outputs []TxOutputReport, changeIndex int) Value {
+	if changeIndex < 0 || changeIndex >= len(outputs) {
+		return Value{}
+	}
+	return outputs[changeIndex].Value.Clone()
+}
+
+func addressStrings(addrs []common.Address) []string {
+	result := make([]string, len(addrs))
+	for i, addr := range addrs {
+		result[i] = addr.String()
+	}
+	return result
+}
+
+func referenceInputRefs(inputs []shelley.ShelleyTransactionInput) []string {
+	refs := make([]string, len(inputs))
+	for i, input := range inputs {
+		refs[i] = hex.EncodeToString(input.TxId.Bytes()) + "#" + strconv.Itoa(int(input.OutputIndex))
+	}
+	return refs
+}
+
+func requiredSignerKeys(signers []common.Blake2b224) []string {
+	keys := make([]string, len(signers))
+	for i, signer := range signers {
+		keys[i] = hex.EncodeToString(signer.Bytes())
+	}
+	return keys
+}
+
+func totalRedeemerExUnits(redeemers []RedeemerReport) common.ExUnits {
+	var total common.ExUnits
+	for _, redeemer := range redeemers {
+		total.Memory += redeemer.ExUnits.Memory
+		total.Steps += redeemer.ExUnits.Steps
+	}
+	return total
+}
+
+func executionUnitFee(pp backend.ProtocolParameters, exUnits common.ExUnits) (int64, error) {
+	if exUnits.Memory == 0 && exUnits.Steps == 0 {
+		return 0, nil
+	}
+	fee := math.Ceil(float64(pp.PriceMem)*float64(exUnits.Memory) + float64(pp.PriceStep)*float64(exUnits.Steps))
+	if !(fee >= 0 && fee < float64(math.MaxInt64)) {
+		return 0, errors.New("execution unit fee out of range")
+	}
+	return int64(fee), nil
+}
+
+func feeSizeComponent(finalFee, padding, referenceScriptFee, executionUnitFee int64) int64 {
+	sizeFee := finalFee - padding - referenceScriptFee - executionUnitFee
+	if sizeFee < 0 {
+		return 0
+	}
+	return sizeFee
+}
+
+func collateralRequired(fee int64, collateralPercent int) (int64, error) {
+	if fee <= 0 || collateralPercent <= 0 {
+		return 0, nil
+	}
+	if fee > (math.MaxInt64-99)/int64(collateralPercent) {
+		return 0, errors.New("collateral requirement overflows")
+	}
+	return (fee*int64(collateralPercent) + 99) / 100, nil
+}
+
+func (a *Apollo) proposalDepositTotal() uint64 {
+	var total uint64
+	for _, proposal := range a.proposalProcedures {
+		deposit := proposal.Deposit()
+		if math.MaxUint64-total < deposit {
+			return math.MaxUint64
+		}
+		total += deposit
+	}
+	return total
+}
+
+func sortRedeemerReports(reports []RedeemerReport) {
+	sort.Slice(reports, func(i, j int) bool {
+		if reports[i].Tag != reports[j].Tag {
+			return reports[i].Tag < reports[j].Tag
+		}
+		if reports[i].Index != reports[j].Index {
+			return reports[i].Index < reports[j].Index
+		}
+		return reports[i].Source < reports[j].Source
+	})
+}
+
+func (r *BuildReport) clone() *BuildReport {
+	if r == nil {
+		return nil
+	}
+	cp := *r
+	cp.Inputs.InputAddresses = append([]string(nil), r.Inputs.InputAddresses...)
+	cp.Inputs.Preselected = cloneUtxoReports(r.Inputs.Preselected)
+	cp.Inputs.Selected = cloneUtxoReports(r.Inputs.Selected)
+	cp.Inputs.Final = cloneUtxoReports(r.Inputs.Final)
+	cp.Inputs.SelectionTarget = r.Inputs.SelectionTarget.Clone()
+	cp.Outputs.Requested = cloneTxOutputReports(r.Outputs.Requested)
+	cp.Outputs.Base = cloneTxOutputReports(r.Outputs.Base)
+	cp.Outputs.Final = cloneTxOutputReports(r.Outputs.Final)
+	cp.Outputs.Change = r.Outputs.Change.Clone()
+	cp.Balance.TotalInput = r.Balance.TotalInput.Clone()
+	cp.Balance.TotalRequired = r.Balance.TotalRequired.Clone()
+	cp.Balance.TotalOutput = r.Balance.TotalOutput.Clone()
+	cp.Balance.Change = r.Balance.Change.Clone()
+	cp.Balance.Withdrawals = r.Balance.Withdrawals.Clone()
+	cp.Balance.Mint = r.Balance.Mint.Clone()
+	cp.Balance.Burn = r.Balance.Burn.Clone()
+	cp.Balance.CertificateRefund = r.Balance.CertificateRefund.Clone()
+	cp.Balance.GovernanceRequired = r.Balance.GovernanceRequired.Clone()
+	cp.Collateral.Inputs = cloneUtxoReports(r.Collateral.Inputs)
+	cp.Collateral.Return = cloneTxOutputReportPtr(r.Collateral.Return)
+	cp.Redeemers = append([]RedeemerReport(nil), r.Redeemers...)
+	cp.Scripts.ReferenceInputRefs = append([]string(nil), r.Scripts.ReferenceInputRefs...)
+	cp.Scripts.ScriptHashes = append([]string(nil), r.Scripts.ScriptHashes...)
+	cp.Scripts.RequiredSignerKeys = append([]string(nil), r.Scripts.RequiredSignerKeys...)
+	return &cp
+}
+
+func cloneUtxoReports(reports []UtxoReport) []UtxoReport {
+	if reports == nil {
+		return nil
+	}
+	cp := make([]UtxoReport, len(reports))
+	for i, report := range reports {
+		cp[i] = report
+		cp[i].Value = report.Value.Clone()
+	}
+	return cp
+}
+
+func cloneTxOutputReports(reports []TxOutputReport) []TxOutputReport {
+	if reports == nil {
+		return nil
+	}
+	cp := make([]TxOutputReport, len(reports))
+	for i, report := range reports {
+		cp[i] = report
+		cp[i].Value = report.Value.Clone()
+	}
+	return cp
+}
+
+func cloneTxOutputReportPtr(report *TxOutputReport) *TxOutputReport {
+	if report == nil {
+		return nil
+	}
+	cp := *report
+	cp.Value = report.Value.Clone()
+	return &cp
+}

--- a/build_report_test.go
+++ b/build_report_test.go
@@ -1,0 +1,359 @@
+package apollo
+
+import (
+	"bytes"
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	plutigoData "github.com/blinklabs-io/plutigo/data"
+)
+
+func TestExplainRequiresBuildReport(t *testing.T) {
+	cc := setupFixedContext()
+	if _, err := New(cc).Explain(); err == nil {
+		t.Fatal("expected Explain to fail before Complete")
+	}
+
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, 10_000_000, 0x01, 0)
+	p, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, err := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AddPayment(p).
+		SetTtl(50000000).
+		Complete()
+	if err != nil {
+		t.Fatal(err)
+	}
+	txCbor, err := a.GetTxCbor()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loaded := New(cc)
+	if _, err := loaded.LoadTxCbor(hex.EncodeToString(txCbor)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loaded.Explain(); err == nil {
+		t.Fatal("expected Explain to fail for a transaction loaded from CBOR")
+	}
+}
+
+func TestBuildReportSimpleTransfer(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, 10_000_000, 0x01, 0)
+
+	p, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, err := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AddPayment(p).
+		SetFeePadding(5_000).
+		SetTtl(50000000).
+		Complete()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := a.Explain()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.TxHash == "" {
+		t.Fatal("expected transaction hash")
+	}
+	if report.TxSize == 0 {
+		t.Fatal("expected transaction size")
+	}
+	if report.CoinSelector != defaultCoinSelector.Name() {
+		t.Fatalf("expected default coin selector %q, got %q", defaultCoinSelector.Name(), report.CoinSelector)
+	}
+	if report.Fees.Final != int64(a.GetTx().Body.TxFee) { //nolint:gosec // test fee is small and produced by Complete
+		t.Fatalf("expected final fee %d, got %d", a.GetTx().Body.TxFee, report.Fees.Final)
+	}
+	if report.Fees.Padding != 5_000 {
+		t.Fatalf("expected fee padding 5000, got %d", report.Fees.Padding)
+	}
+	if report.Inputs.AvailableUtxoCount != 1 {
+		t.Fatalf("expected 1 available UTxO, got %d", report.Inputs.AvailableUtxoCount)
+	}
+	if len(report.Inputs.Preselected) != 0 {
+		t.Fatalf("expected no preselected inputs, got %d", len(report.Inputs.Preselected))
+	}
+	if len(report.Inputs.Selected) != 1 {
+		t.Fatalf("expected 1 selected input, got %d", len(report.Inputs.Selected))
+	}
+	if len(report.Inputs.Final) != 1 {
+		t.Fatalf("expected 1 final input, got %d", len(report.Inputs.Final))
+	}
+	if report.Balance.TotalInput.Coin != 10_000_000 {
+		t.Fatalf("expected total input 10000000, got %d", report.Balance.TotalInput.Coin)
+	}
+	if len(report.Outputs.Requested) != 1 {
+		t.Fatalf("expected 1 requested output, got %d", len(report.Outputs.Requested))
+	}
+	if len(report.Outputs.Final) < 2 {
+		t.Fatalf("expected payment and change outputs, got %d", len(report.Outputs.Final))
+	}
+	if report.Outputs.ChangeIndex < 0 {
+		t.Fatal("expected a change output")
+	}
+	if !report.Outputs.Final[report.Outputs.ChangeIndex].IsChange {
+		t.Fatal("expected change output to be marked")
+	}
+	if report.Outputs.Change.Coin == 0 {
+		t.Fatal("expected non-zero change")
+	}
+	if report.Balance.Change.Coin != report.Outputs.Change.Coin {
+		t.Fatalf("expected balance change %d, got %d", report.Outputs.Change.Coin, report.Balance.Change.Coin)
+	}
+
+	report.Inputs.Final[0].Value.Coin = 1
+	report.Outputs.Final[0].Value.Coin = 1
+	reportAgain, err := a.Explain()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reportAgain.Inputs.Final[0].Value.Coin == 1 {
+		t.Fatal("Explain returned a mutable input report")
+	}
+	if reportAgain.Outputs.Final[0].Value.Coin == 1 {
+		t.Fatal("Explain returned a mutable output report")
+	}
+
+	clone := a.Clone()
+	cloneReport, err := clone.Explain()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cloneReport.Outputs.Change.Coin = 1
+	if cloneReport.Outputs.Change.Coin == report.Outputs.Change.Coin {
+		t.Fatal("test mutation did not change clone report copy")
+	}
+	clone.buildReport.Outputs.Change.Coin = 1
+	originalReport, err := a.Explain()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if originalReport.Outputs.Change.Coin == 1 {
+		t.Fatal("Clone shared build report state with original")
+	}
+}
+
+func TestBuildReportPreselectedAndSelectedInputs(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	var preselectedHash common.Blake2b256
+	preselectedHash[0] = 0x01
+	var selectedHash common.Blake2b256
+	selectedHash[0] = 0x02
+	preselected := makeTestUtxo(t, preselectedHash, 0, 3_000_000)
+	selected := makeTestUtxo(t, selectedHash, 0, 10_000_000)
+
+	p, err := NewPayment(validTestAddrBech32, 8_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, err := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AddInput(preselected).
+		AddLoadedUTxOs(selected).
+		AddPayment(p).
+		SetTtl(50000000).
+		Complete()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := a.Explain()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Inputs.Preselected) != 1 {
+		t.Fatalf("expected 1 preselected input, got %d", len(report.Inputs.Preselected))
+	}
+	if report.Inputs.Preselected[0].Ref != utxoRef(preselected) {
+		t.Fatalf("expected preselected ref %s, got %s", utxoRef(preselected), report.Inputs.Preselected[0].Ref)
+	}
+	if len(report.Inputs.Selected) != 1 {
+		t.Fatalf("expected 1 selected input, got %d", len(report.Inputs.Selected))
+	}
+	if report.Inputs.Selected[0].Ref != utxoRef(selected) {
+		t.Fatalf("expected selected ref %s, got %s", utxoRef(selected), report.Inputs.Selected[0].Ref)
+	}
+	if len(report.Inputs.Final) != 2 {
+		t.Fatalf("expected 2 final inputs, got %d", len(report.Inputs.Final))
+	}
+	if report.Inputs.SelectionTarget.Coin == 0 {
+		t.Fatal("expected non-zero selection target")
+	}
+}
+
+func TestBuildReportMinUtxoIncrease(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, 10_000_000, 0x01, 0)
+
+	p, err := NewPayment(validTestAddrBech32, 1, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, err := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AddPayment(p).
+		SetTtl(50000000).
+		Complete()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := a.Explain()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Outputs.Requested) != 1 || len(report.Outputs.Base) != 1 {
+		t.Fatalf("expected one requested/base output, got %d/%d", len(report.Outputs.Requested), len(report.Outputs.Base))
+	}
+	if report.Outputs.Requested[0].Value.Coin != 1 {
+		t.Fatalf("expected requested output to preserve original lovelace, got %d", report.Outputs.Requested[0].Value.Coin)
+	}
+	if report.Outputs.Requested[0].MinUtxoIncrease == 0 {
+		t.Fatal("expected requested output to report a min-UTxO shortfall")
+	}
+	if report.Outputs.Base[0].Value.Coin <= report.Outputs.Requested[0].Value.Coin {
+		t.Fatalf("expected base output lovelace to increase, requested=%d base=%d", report.Outputs.Requested[0].Value.Coin, report.Outputs.Base[0].Value.Coin)
+	}
+	if report.Outputs.Base[0].MinUtxoIncrease == 0 {
+		t.Fatal("expected base output to report the applied min-UTxO increase")
+	}
+}
+
+func TestBuildReportScriptCollateralAndRedeemer(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, 30_000_000, 0x01, 0)
+	addTestUtxo(cc, addr, 20_000_000, 0x02, 0)
+
+	policy := "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"
+	datum := common.Datum{Data: plutigoData.NewInteger(big.NewInt(1))}
+	exUnits := common.ExUnits{Memory: 1_000, Steps: 2_000}
+	p, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, err := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AttachScript(common.PlutusV2Script([]byte{0x01, 0x02})).
+		DisableExecutionUnitsEstimation().
+		Mint(NewUnit(policy, "746f6b656e", 1), &datum, &exUnits).
+		AddPayment(p).
+		SetTtl(50000000).
+		Complete()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := a.Explain()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Scripts.PlutusV2 != 1 || len(report.Scripts.ScriptHashes) != 1 {
+		t.Fatalf("expected one attached PlutusV2 script, got count=%d hashes=%d", report.Scripts.PlutusV2, len(report.Scripts.ScriptHashes))
+	}
+	if len(report.Collateral.Inputs) != 1 {
+		t.Fatalf("expected one collateral input, got %d", len(report.Collateral.Inputs))
+	}
+	if !report.Collateral.AutoSelected {
+		t.Fatal("expected auto-selected collateral")
+	}
+	if report.Collateral.Required == 0 || report.Collateral.Total < report.Collateral.Required {
+		t.Fatalf("expected collateral total %d to cover required %d", report.Collateral.Total, report.Collateral.Required)
+	}
+	if report.Collateral.Return == nil {
+		t.Fatal("expected collateral return for oversized collateral")
+	}
+	if len(report.Redeemers) != 1 {
+		t.Fatalf("expected one redeemer, got %d", len(report.Redeemers))
+	}
+	if report.Redeemers[0].Tag != common.RedeemerTagMint || report.Redeemers[0].Source != policy {
+		t.Fatalf("unexpected redeemer mapping: %+v", report.Redeemers[0])
+	}
+	if report.Redeemers[0].ExUnits != exUnits {
+		t.Fatalf("expected redeemer ExUnits %+v, got %+v", exUnits, report.Redeemers[0].ExUnits)
+	}
+	if report.Fees.ExecutionUnits != exUnits || report.Fees.ExecutionUnitFee == 0 {
+		t.Fatalf("expected execution-unit fee details, got units=%+v fee=%d", report.Fees.ExecutionUnits, report.Fees.ExecutionUnitFee)
+	}
+	if !report.Balance.Mint.HasAssets() {
+		t.Fatal("expected mint balance component to include assets")
+	}
+}
+
+func TestBuildReportReferenceScriptFeeDetails(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, 5_000_000, 0x01, 0)
+	addTestUtxo(cc, addr, 5_000_000, 0x02, 0)
+
+	hashHex := "eeff000000000000000000000000000000000000000000000000000000000000"
+	hashBytes, err := hex.DecodeString(hashHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var refTxHash common.Blake2b256
+	copy(refTxHash[:], hashBytes)
+	cc.AddUtxoByRef(common.Utxo{
+		Id: shelley.ShelleyTransactionInput{TxId: refTxHash, OutputIndex: 0},
+		Output: &babbage.BabbageTransactionOutput{
+			OutputAddress: addr,
+			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 2_000_000},
+			TxOutScriptRef: &common.ScriptRef{
+				Type:   common.ScriptRefTypePlutusV2,
+				Script: common.PlutusV2Script(bytes.Repeat([]byte{0x42}, 60_000)),
+			},
+		},
+	})
+
+	p, err := NewPayment(validTestAddrBech32, 4_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AddPayment(p)
+	a, err = a.AddReferenceInput(hashHex, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.Complete(); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := a.Explain()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Fees.ReferenceScriptBytes != 60_000 {
+		t.Fatalf("expected 60000 reference-script bytes, got %d", report.Fees.ReferenceScriptBytes)
+	}
+	if report.Fees.ReferenceScriptFee == 0 || report.Fees.ReferenceScriptReserve == 0 {
+		t.Fatalf("expected reference-script fee details, got fee=%d reserve=%d", report.Fees.ReferenceScriptFee, report.Fees.ReferenceScriptReserve)
+	}
+	if report.Fees.Size == 0 {
+		t.Fatal("expected size fee component")
+	}
+	if len(report.Scripts.ReferenceInputRefs) != 1 || report.Scripts.ReferenceInputRefs[0] != hashHex+"#0" {
+		t.Fatalf("unexpected reference input refs: %v", report.Scripts.ReferenceInputRefs)
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,5 +8,6 @@ Documentation for the Apollo transaction building library for Cardano.
 - **[Data Attachment](data_attachment/README.md)** — Attaching Plutus datums (hash and inline) and reference scripts to transaction outputs; CLI parity for datum and reference script flags.
 - **[Staking Functionalities](staking_functionalities/README.md)** — Stake key registration and deregistration, pool and vote (DRep) delegation, combined certificates, and reward withdrawals; CLI parity for stake-address and withdrawal flags.
 - **[Conway Governance](conway_governance/README.md)** — DRep registration/retirement/update, constitutional committee key authorization and resignation, casting votes, submitting governance action proposals, and treasury donations; CLI parity for `conway governance` commands and CIP-1694.
+- **[Build Reports](build_report.md)** — Using `Explain()` after `CompleteContext` to inspect selected inputs, outputs, change, fees, collateral, balance components, and redeemer mappings.
 
 All sections reference **cardano-cli** 10.14.0.0 where applicable. API details and examples are based on the Apollo codebase (see [AGENTS.md](../AGENTS.md) for build and test commands).

--- a/docs/build_report.md
+++ b/docs/build_report.md
@@ -1,0 +1,48 @@
+# Build Reports
+
+`Complete` and `CompleteContext` store a diagnostic `BuildReport` for the
+transaction they build. Call `Explain` after a successful build to inspect the
+builder's decisions without decoding CBOR or reading private builder fields.
+
+```go
+a, err := apollo.New(chainContext).
+    SetWallet(wallet).
+    AddPayment(payment).
+    CompleteContext(ctx)
+if err != nil {
+    return err
+}
+
+report, err := a.Explain()
+if err != nil {
+    return err
+}
+
+fmt.Println(report.Fees.Final)
+fmt.Println(report.Inputs.Selected)
+fmt.Println(report.Outputs.Change)
+```
+
+The report includes:
+
+- preselected, coin-selected, and final ordered inputs;
+- requested outputs, min-UTxO-adjusted base outputs, final outputs, and the
+  change output;
+- each output's computed min lovelace and any min-UTxO increase applied by the
+  builder;
+- final fee, size fee component, fee padding, reference-script byte/fee details,
+  and execution-unit totals/fee;
+- withdrawals, mints, burns, certificate deposits/refunds, and governance costs;
+- collateral inputs, required collateral, total collateral, collateral return,
+  auto-selection, and overlap details;
+- redeemer tag/index mappings after canonical ordering;
+- reference input refs, attached script hashes, and required signer key hashes.
+
+`Explain` returns a deep copy of the stored report. Mutating the returned value
+does not alter the builder. Transactions loaded with `LoadTxCbor` do not have a
+build report because the original build decisions are not recoverable from CBOR.
+
+`Explain` does not query the backend. Backend-dependent values such as protocol
+parameters, reference-script sizes, collateral requirements, and min-UTxO values
+are captured during `Complete` or `CompleteContext` while the transaction is
+being built.

--- a/docs/v2_migration/MIGRATION.md
+++ b/docs/v2_migration/MIGRATION.md
@@ -481,5 +481,6 @@ a, err = a.SetWalletFromMnemonicWithPassphrase(mnemonic, "pass")  // with passph
 - `SubmitContext(ctx) (Blake2b256, error)`
 - `GetTx() *ConwayTransaction`
 - `GetTxCbor() ([]byte, error)`
+- `Explain() (*BuildReport, error)`
 - `LoadTxCbor(hex) (*Apollo, error)`
 - `Clone() *Apollo`


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a Build Report and `Explain()` API to inspect how a transaction was built after `Complete`/`CompleteContext`, improving debuggability of inputs, outputs, change, fees, collateral, redeemers, and scripts. Also adds documentation and tests.

- New Features
  - Generate a `BuildReport` during `Complete`/`CompleteContext` and expose it via `Explain()`.
  - Report covers: requested/base/final outputs and change (with min-UTxO increases), preselected/selected/final inputs, fees (size component, padding, reference script bytes/fee, execution units/fee), balance components (mint/burn/withdrawals/certificates/governance), collateral (required/total/return/auto-selected), redeemer mappings, reference inputs, script hashes, and required signers.
  - `Clone()` deep-copies the build report; `LoadTxCbor()` clears it; `Explain()` errors if no report exists.
  - Docs: added `docs/build_report.md`, linked from `docs/README.md`; `Explain()` included in v2 migration API list.

<sup>Written for commit b6bc5eab8464739158cadade9bf2c6c414a3a751. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/salvionied-apollo/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

