### PR TITLE
feat: CIP-0002 random improve coin selection

### DIFF
--- a/coinselection.go
+++ b/coinselection.go
@@ -19,6 +19,8 @@ type CoinSelector interface {
 	Select(available []common.Utxo, target Value) ([]common.Utxo, error)
 }
 
+var errInsufficientUtxos = errors.New("insufficient UTxOs to cover required value")
+
 // defaultCoinSelector is used by Complete when no selector is configured.
 // MACS is the default: benchmarks (see docs/design/2026-06-11-macs-coin-
 // selection-design.md) show it selects far fewer inputs on multi-asset
@@ -88,5 +90,5 @@ func (s *LargestFirstSelector) Select(available []common.Utxo, target Value) ([]
 			return selected, nil
 		}
 	}
-	return nil, errors.New("insufficient UTxOs to cover required value")
+	return nil, errInsufficientUtxos
 }

--- a/coinselection_bench_test.go
+++ b/coinselection_bench_test.go
@@ -155,7 +155,12 @@ func benchScenarios(tb testing.TB) []benchScenario {
 }
 
 func BenchmarkCoinSelection(b *testing.B) {
-	selectors := []CoinSelector{&LargestFirstSelector{}, &MACSSelector{}}
+	selectors := []CoinSelector{
+		&LargestFirstSelector{},
+		NewRandomImproveSelector(),
+		NewRandomImproveThenLargestFirstSelector(),
+		&MACSSelector{},
+	}
 	for _, sc := range benchScenarios(b) {
 		for _, sel := range selectors {
 			b.Run(sc.name+"/"+sel.Name(), func(b *testing.B) {
@@ -193,6 +198,8 @@ func TestCoinSelectionComparison(t *testing.T) {
 		sel   CoinSelector
 	}{
 		{"largest-first", &LargestFirstSelector{}},
+		{"random-improve", NewRandomImproveSelector()},
+		{"random-improve-largest-first", NewRandomImproveThenLargestFirstSelector()},
 		{"macs-pure", &MACSSelector{}},
 		{"macs-sweep", NewMACSSelector()},
 	}

--- a/coinselection_test.go
+++ b/coinselection_test.go
@@ -1,6 +1,7 @@
 package apollo
 
 import (
+	"errors"
 	"math/big"
 	"strings"
 	"testing"
@@ -173,9 +174,29 @@ func TestLargestFirstSelectorConformance(t *testing.T) {
 	runSelectorConformance(t, func() CoinSelector { return &LargestFirstSelector{} })
 }
 
+func TestRandomImproveSelectorConformance(t *testing.T) {
+	runSelectorConformance(t, func() CoinSelector { return NewRandomImproveSelector() })
+}
+
+func TestRandomImproveThenLargestFirstSelectorConformance(t *testing.T) {
+	runSelectorConformance(t, func() CoinSelector { return NewRandomImproveThenLargestFirstSelector() })
+}
+
 func TestLargestFirstSelectorName(t *testing.T) {
 	if name := (&LargestFirstSelector{}).Name(); name != "largest-first" {
 		t.Errorf("expected name largest-first, got %q", name)
+	}
+}
+
+func TestRandomImproveSelectorName(t *testing.T) {
+	if name := NewRandomImproveSelector().Name(); name != "random-improve" {
+		t.Errorf("expected name random-improve, got %q", name)
+	}
+}
+
+func TestRandomImproveThenLargestFirstSelectorName(t *testing.T) {
+	if name := NewRandomImproveThenLargestFirstSelector().Name(); name != "random-improve-largest-first" {
+		t.Errorf("expected name random-improve-largest-first, got %q", name)
 	}
 }
 
@@ -202,6 +223,95 @@ func TestLargestFirstSelectorOrder(t *testing.T) {
 	}
 	if got := selected[1].Output.Amount().Uint64(); got != 5_000_000 {
 		t.Errorf("expected second selection of 5 ADA, got %d lovelace", got)
+	}
+}
+
+func TestRandomImproveSelectorImprovesTowardDoubleTarget(t *testing.T) {
+	pool := []common.Utxo{
+		makeSelectorUtxo(t, 0x01, 0, 10_000_000, nil),
+		makeSelectorUtxo(t, 0x02, 0, 5_000_000, nil),
+	}
+	selected, err := NewRandomImproveSelector().Select(pool, NewSimpleValue(10_000_000))
+	if err != nil {
+		t.Fatalf("Select failed: %v", err)
+	}
+	if len(selected) != 2 {
+		t.Fatalf("expected improvement to add second UTxO, got %d selections", len(selected))
+	}
+	if got := sumSelected(t, selected).Coin; got != 15_000_000 {
+		t.Errorf("expected improved total of 15 ADA, got %d lovelace", got)
+	}
+}
+
+func TestRandomImproveSelectorDoesNotImprovePastDoubleTarget(t *testing.T) {
+	pool := []common.Utxo{
+		makeSelectorUtxo(t, 0x01, 0, 10_000_000, nil),
+		makeSelectorUtxo(t, 0x02, 0, 11_000_000, nil),
+	}
+	selected, err := NewRandomImproveSelector().Select(pool, NewSimpleValue(10_000_000))
+	if err != nil {
+		t.Fatalf("Select failed: %v", err)
+	}
+	if len(selected) != 1 {
+		t.Fatalf("expected improvement to skip overshooting UTxO, got %d selections", len(selected))
+	}
+	if got := sumSelected(t, selected).Coin; got > 20_000_000 {
+		t.Errorf("selection exceeded twice the target: %d lovelace", got)
+	}
+}
+
+func TestRandomImproveSelectorImprovesTargetAssets(t *testing.T) {
+	pool := []common.Utxo{
+		makeSelectorUtxo(t, 0x01, 0, 2_000_000, makeTestAssets(0xAA, "tokenA", 10)),
+		makeSelectorUtxo(t, 0x02, 0, 1_000_000, makeTestAssets(0xAA, "tokenA", 5)),
+	}
+	target := NewValue(2_000_000, makeTestAssets(0xAA, "tokenA", 10))
+	selected, err := NewRandomImproveSelector().Select(pool, target)
+	if err != nil {
+		t.Fatalf("Select failed: %v", err)
+	}
+	got := sumSelected(t, selected)
+	if got.Coin != 3_000_000 {
+		t.Fatalf("expected improved coin total of 3 ADA, got %d lovelace", got.Coin)
+	}
+	var policy common.Blake2b224
+	policy[0] = 0xAA
+	qty := got.Assets.Asset(policy, []byte("tokenA"))
+	if qty == nil || qty.Cmp(big.NewInt(15)) != 0 {
+		t.Fatalf("expected improved token total of 15, got %v", qty)
+	}
+}
+
+type alwaysFailSelector struct{}
+
+func (s alwaysFailSelector) Name() string { return "always-fail" }
+
+func (s alwaysFailSelector) Select([]common.Utxo, Value) ([]common.Utxo, error) {
+	return nil, errors.New("forced failure")
+}
+
+func TestRandomImproveThenLargestFirstSelectorFallsBack(t *testing.T) {
+	pool := []common.Utxo{
+		makeSelectorUtxo(t, 0x01, 0, 3_000_000, nil),
+		makeSelectorUtxo(t, 0x02, 0, 10_000_000, nil),
+		makeSelectorUtxo(t, 0x03, 0, 5_000_000, nil),
+	}
+	selector := &RandomImproveThenLargestFirstSelector{
+		RandomImprove: alwaysFailSelector{},
+		Fallback:      &LargestFirstSelector{},
+	}
+	selected, err := selector.Select(pool, NewSimpleValue(12_000_000))
+	if err != nil {
+		t.Fatalf("Select failed: %v", err)
+	}
+	if len(selected) != 2 {
+		t.Fatalf("expected 2 UTxOs selected by fallback, got %d", len(selected))
+	}
+	if got := selected[0].Output.Amount().Uint64(); got != 10_000_000 {
+		t.Errorf("expected fallback to select 10 ADA first, got %d lovelace", got)
+	}
+	if got := selected[1].Output.Amount().Uint64(); got != 5_000_000 {
+		t.Errorf("expected fallback to select 5 ADA second, got %d lovelace", got)
 	}
 }
 

--- a/coinselection_test.go
+++ b/coinselection_test.go
@@ -290,6 +290,14 @@ func (s alwaysFailSelector) Select([]common.Utxo, Value) ([]common.Utxo, error) 
 	return nil, errors.New("forced failure")
 }
 
+type alwaysInsufficientSelector struct{}
+
+func (s alwaysInsufficientSelector) Name() string { return "always-insufficient" }
+
+func (s alwaysInsufficientSelector) Select([]common.Utxo, Value) ([]common.Utxo, error) {
+	return nil, errInsufficientUtxos
+}
+
 func TestRandomImproveThenLargestFirstSelectorFallsBack(t *testing.T) {
 	pool := []common.Utxo{
 		makeSelectorUtxo(t, 0x01, 0, 3_000_000, nil),
@@ -297,7 +305,7 @@ func TestRandomImproveThenLargestFirstSelectorFallsBack(t *testing.T) {
 		makeSelectorUtxo(t, 0x03, 0, 5_000_000, nil),
 	}
 	selector := &RandomImproveThenLargestFirstSelector{
-		RandomImprove: alwaysFailSelector{},
+		RandomImprove: alwaysInsufficientSelector{},
 		Fallback:      &LargestFirstSelector{},
 	}
 	selected, err := selector.Select(pool, NewSimpleValue(12_000_000))
@@ -312,6 +320,72 @@ func TestRandomImproveThenLargestFirstSelectorFallsBack(t *testing.T) {
 	}
 	if got := selected[1].Output.Amount().Uint64(); got != 5_000_000 {
 		t.Errorf("expected fallback to select 5 ADA second, got %d lovelace", got)
+	}
+}
+
+func TestRandomImproveThenLargestFirstSelectorDoesNotFallbackOnPrimaryError(t *testing.T) {
+	pool := []common.Utxo{
+		makeSelectorUtxo(t, 0x01, 0, 10_000_000, nil),
+	}
+	fallback := &recordingSelector{inner: &LargestFirstSelector{}}
+	selector := &RandomImproveThenLargestFirstSelector{
+		RandomImprove: alwaysFailSelector{},
+		Fallback:      fallback,
+	}
+	_, err := selector.Select(pool, NewSimpleValue(1_000_000))
+	if err == nil {
+		t.Fatal("expected primary error")
+	}
+	if fallback.called {
+		t.Fatal("fallback should not run for non-selection primary errors")
+	}
+	if !strings.Contains(err.Error(), "forced failure") {
+		t.Fatalf("expected forced failure error, got: %v", err)
+	}
+}
+
+func TestRandomImproveThenLargestFirstSelectorDoesNotFallbackOnInvalidAmount(t *testing.T) {
+	good := makeSelectorUtxo(t, 0x01, 0, 10_000_000, nil)
+	badBase := makeSelectorUtxo(t, 0x02, 0, 1_000_000, nil)
+	tooBig := new(big.Int).Lsh(big.NewInt(1), 64)
+	bad := common.Utxo{Id: badBase.Id, Output: badAmountOutput{badBase.Output, tooBig}}
+	fallback := &recordingSelector{inner: &LargestFirstSelector{}}
+	selector := &RandomImproveThenLargestFirstSelector{
+		Fallback: fallback,
+	}
+
+	_, err := selector.Select([]common.Utxo{good, bad}, NewSimpleValue(1_000_000))
+	if err == nil {
+		t.Fatal("expected invalid amount error")
+	}
+	if fallback.called {
+		t.Fatal("fallback should not run for invalid backend amount errors")
+	}
+	if !strings.Contains(err.Error(), "invalid lovelace amount") {
+		t.Fatalf("expected invalid lovelace amount error, got: %v", err)
+	}
+}
+
+func TestRandomImproveThenLargestFirstSelectorDoesNotFallbackOnOverflow(t *testing.T) {
+	maxUint64 := ^uint64(0)
+	pool := []common.Utxo{
+		makeSelectorUtxo(t, 0x01, 0, maxUint64-1, nil),
+		makeSelectorUtxo(t, 0x02, 0, 2, nil),
+	}
+	fallback := &recordingSelector{inner: &LargestFirstSelector{}}
+	selector := &RandomImproveThenLargestFirstSelector{
+		Fallback: fallback,
+	}
+
+	_, err := selector.Select(pool, NewSimpleValue(maxUint64))
+	if err == nil {
+		t.Fatal("expected overflow error")
+	}
+	if fallback.called {
+		t.Fatal("fallback should not run for Random-Improve overflow errors")
+	}
+	if !strings.Contains(err.Error(), "overflow") {
+		t.Fatalf("expected overflow error, got: %v", err)
 	}
 }
 

--- a/macs.go
+++ b/macs.go
@@ -2,7 +2,6 @@ package apollo
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"math/big"
 	"sort"
@@ -127,7 +126,7 @@ func (s *MACSSelector) Select(available []common.Utxo, target Value) ([]common.U
 		}
 		pick := macsBestCandidate(cands, selected, classes[clsIdx], avgs[clsIdx])
 		if pick == nil {
-			return nil, errors.New("insufficient UTxOs to cover required value")
+			return nil, errInsufficientUtxos
 		}
 		selected[pick.cand.ref] = true
 		picks = append(picks, pick)

--- a/random_improve.go
+++ b/random_improve.go
@@ -66,7 +66,7 @@ func (s *RandomImproveSelector) Select(available []common.Utxo, target Value) ([
 		result = append(result, cand.utxo)
 	}
 	if !total.GreaterOrEqual(target) {
-		return nil, errors.New("insufficient UTxOs to cover required value")
+		return nil, errInsufficientUtxos
 	}
 
 	ideal, err := target.Add(target)
@@ -104,13 +104,13 @@ func (s *RandomImproveSelector) Select(available []common.Utxo, target Value) ([
 }
 
 // RandomImproveThenLargestFirstSelector follows the Cardano Wallet strategy
-// from CIP-0002: try Random-Improve first, then fall back to Largest-First if
-// Random-Improve cannot produce a valid selection.
+// from CIP-0002: try Random-Improve first, then fall back to Largest-First
+// only when Random-Improve cannot cover the target from the available pool.
 type RandomImproveThenLargestFirstSelector struct {
 	// RandomImprove is the primary selector. If nil, NewRandomImproveSelector
 	// is used.
 	RandomImprove CoinSelector
-	// Fallback is used when RandomImprove returns an error. If nil,
+	// Fallback is used when RandomImprove reports insufficient UTxOs. If nil,
 	// LargestFirstSelector is used.
 	Fallback CoinSelector
 }
@@ -135,6 +135,9 @@ func (s *RandomImproveThenLargestFirstSelector) Select(available []common.Utxo, 
 	selected, err := primary.Select(available, target)
 	if err == nil {
 		return selected, nil
+	}
+	if !errors.Is(err, errInsufficientUtxos) {
+		return nil, fmt.Errorf("%s failed: %w", primary.Name(), err)
 	}
 
 	fallback := s.Fallback

--- a/random_improve.go
+++ b/random_improve.go
@@ -1,0 +1,284 @@
+package apollo
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"sort"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+const (
+	randomImproveCoverSalt   int64 = 0x4349503030303201
+	randomImproveImproveSalt int64 = 0x52494d50524f5645
+)
+
+// RandomImproveSelector implements the Random-Improve algorithm described by
+// CIP-0002, adapted to Apollo's aggregate CoinSelector interface. It first
+// randomly covers the requested value, then tries to add remaining UTxOs that
+// move the selection closer to the ideal value of twice the target.
+//
+// The randomness is deterministic: the same Seed, available pool, and target
+// produce the same selection. This preserves the CoinSelector contract and
+// makes transaction construction reproducible in tests.
+type RandomImproveSelector struct {
+	// Seed controls deterministic pseudo-random UTxO ordering. The zero value
+	// is a valid deterministic seed.
+	Seed int64
+}
+
+// NewRandomImproveSelector returns a deterministic Random-Improve selector.
+func NewRandomImproveSelector() *RandomImproveSelector {
+	return &RandomImproveSelector{}
+}
+
+// Name returns the algorithm's identifier.
+func (s *RandomImproveSelector) Name() string { return "random-improve" }
+
+// Select returns a subset of available whose summed value covers target.
+func (s *RandomImproveSelector) Select(available []common.Utxo, target Value) ([]common.Utxo, error) {
+	if target.Coin == 0 && !target.HasAssets() {
+		return nil, nil
+	}
+
+	cands, err := randomImproveCandidates(available)
+	if err != nil {
+		return nil, err
+	}
+
+	coverOrder := randomImproveShuffle(cands, s.Seed^randomImproveCoverSalt)
+	selected := make(map[string]bool, len(coverOrder))
+	result := make([]common.Utxo, 0, len(coverOrder))
+	total := Value{}
+
+	for _, cand := range coverOrder {
+		if total.GreaterOrEqual(target) {
+			break
+		}
+		total, err = total.Add(cand.value)
+		if err != nil {
+			return nil, fmt.Errorf("selection value overflow after adding UTxO %s: %w", cand.ref, err)
+		}
+		selected[cand.ref] = true
+		result = append(result, cand.utxo)
+	}
+	if !total.GreaterOrEqual(target) {
+		return nil, errors.New("insufficient UTxOs to cover required value")
+	}
+
+	ideal, err := target.Add(target)
+	if err != nil {
+		// A target above half of uint64's range cannot be represented at
+		// twice its value. The covering selection is still valid, so skip the
+		// optional improvement phase instead of failing a satisfiable request.
+		return result, nil
+	}
+
+	improveOrder := randomImproveShuffle(cands, s.Seed^randomImproveImproveSalt)
+	for _, cand := range improveOrder {
+		if selected[cand.ref] {
+			continue
+		}
+		if randomImproveHasUntargetedAssets(cand.value, target) {
+			continue
+		}
+		next, err := total.Add(cand.value)
+		if err != nil {
+			return nil, fmt.Errorf("selection value overflow after adding UTxO %s: %w", cand.ref, err)
+		}
+		if !randomImproveWithinIdeal(next, ideal) {
+			continue
+		}
+		if randomImproveDistance(next, ideal).Cmp(randomImproveDistance(total, ideal)) >= 0 {
+			continue
+		}
+		total = next
+		selected[cand.ref] = true
+		result = append(result, cand.utxo)
+	}
+
+	return result, nil
+}
+
+// RandomImproveThenLargestFirstSelector follows the Cardano Wallet strategy
+// from CIP-0002: try Random-Improve first, then fall back to Largest-First if
+// Random-Improve cannot produce a valid selection.
+type RandomImproveThenLargestFirstSelector struct {
+	// RandomImprove is the primary selector. If nil, NewRandomImproveSelector
+	// is used.
+	RandomImprove CoinSelector
+	// Fallback is used when RandomImprove returns an error. If nil,
+	// LargestFirstSelector is used.
+	Fallback CoinSelector
+}
+
+// NewRandomImproveThenLargestFirstSelector returns a CIP-0002 style selector
+// that tries Random-Improve before Largest-First.
+func NewRandomImproveThenLargestFirstSelector() *RandomImproveThenLargestFirstSelector {
+	return &RandomImproveThenLargestFirstSelector{}
+}
+
+// Name returns the algorithm's identifier.
+func (s *RandomImproveThenLargestFirstSelector) Name() string {
+	return "random-improve-largest-first"
+}
+
+// Select returns a subset of available whose summed value covers target.
+func (s *RandomImproveThenLargestFirstSelector) Select(available []common.Utxo, target Value) ([]common.Utxo, error) {
+	primary := s.RandomImprove
+	if primary == nil {
+		primary = NewRandomImproveSelector()
+	}
+	selected, err := primary.Select(available, target)
+	if err == nil {
+		return selected, nil
+	}
+
+	fallback := s.Fallback
+	if fallback == nil {
+		fallback = &LargestFirstSelector{}
+	}
+	selected, fallbackErr := fallback.Select(available, target)
+	if fallbackErr != nil {
+		return nil, fmt.Errorf("%s failed: %w; %s failed: %w", primary.Name(), err, fallback.Name(), fallbackErr)
+	}
+	return selected, nil
+}
+
+type randomImproveCandidate struct {
+	utxo  common.Utxo
+	ref   string
+	value Value
+}
+
+func randomImproveCandidates(available []common.Utxo) ([]randomImproveCandidate, error) {
+	cands := make([]randomImproveCandidate, 0, len(available))
+	for i := range available {
+		amt := available[i].Output.Amount()
+		if amt == nil || !amt.IsUint64() {
+			return nil, fmt.Errorf("UTxO %s has an invalid lovelace amount", utxoRef(available[i]))
+		}
+		cands = append(cands, randomImproveCandidate{
+			utxo: available[i],
+			ref:  utxoRef(available[i]),
+			value: NewValue(
+				amt.Uint64(),
+				CloneMultiAsset(available[i].Output.Assets()),
+			),
+		})
+	}
+	sort.Slice(cands, func(i, j int) bool {
+		return cands[i].ref < cands[j].ref
+	})
+	return cands, nil
+}
+
+func randomImproveShuffle(cands []randomImproveCandidate, seed int64) []randomImproveCandidate {
+	shuffled := make([]randomImproveCandidate, len(cands))
+	copy(shuffled, cands)
+	rng := rand.New(rand.NewSource(seed)) //nolint:gosec // deterministic pseudo-random ordering is required here.
+	rng.Shuffle(len(shuffled), func(i, j int) {
+		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+	})
+	return shuffled
+}
+
+func randomImproveHasUntargetedAssets(value Value, target Value) bool {
+	if value.Assets == nil {
+		return false
+	}
+	for _, policy := range value.Assets.Policies() {
+		for _, name := range value.Assets.Assets(policy) {
+			qty := value.Assets.Asset(policy, name)
+			if qty == nil || qty.Sign() <= 0 {
+				continue
+			}
+			if target.Assets == nil {
+				return true
+			}
+			targetQty := target.Assets.Asset(policy, name)
+			if targetQty == nil || targetQty.Sign() <= 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func randomImproveWithinIdeal(value Value, ideal Value) bool {
+	if value.Coin > ideal.Coin {
+		return false
+	}
+	if ideal.Assets == nil {
+		return true
+	}
+	if value.Assets == nil {
+		return true
+	}
+	for _, policy := range ideal.Assets.Policies() {
+		for _, name := range ideal.Assets.Assets(policy) {
+			idealQty := ideal.Assets.Asset(policy, name)
+			if idealQty == nil || idealQty.Sign() <= 0 {
+				continue
+			}
+			valueQty := value.Assets.Asset(policy, name)
+			if valueQty != nil && valueQty.Cmp(idealQty) > 0 {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func randomImproveDistance(value Value, ideal Value) *big.Int {
+	dist := new(big.Int).SetUint64(absDiffUint64(value.Coin, ideal.Coin))
+	if ideal.Assets == nil {
+		return dist
+	}
+	for _, policy := range sortedPolicies(ideal.Assets) {
+		for _, name := range sortedAssetNames(ideal.Assets, policy) {
+			idealQty := ideal.Assets.Asset(policy, name)
+			if idealQty == nil || idealQty.Sign() <= 0 {
+				continue
+			}
+			valueQty := big.NewInt(0)
+			if value.Assets != nil {
+				if qty := value.Assets.Asset(policy, name); qty != nil {
+					valueQty = qty
+				}
+			}
+			diff := new(big.Int).Sub(idealQty, valueQty)
+			if diff.Sign() < 0 {
+				diff.Neg(diff)
+			}
+			dist.Add(dist, diff)
+		}
+	}
+	return dist
+}
+
+func absDiffUint64(a, b uint64) uint64 {
+	if a > b {
+		return a - b
+	}
+	return b - a
+}
+
+func sortedPolicies(m *common.MultiAsset[common.MultiAssetTypeOutput]) []common.Blake2b224 {
+	policies := m.Policies()
+	sort.Slice(policies, func(i, j int) bool {
+		return bytes.Compare(policies[i].Bytes(), policies[j].Bytes()) < 0
+	})
+	return policies
+}
+
+func sortedAssetNames(m *common.MultiAsset[common.MultiAssetTypeOutput], policy common.Blake2b224) [][]byte {
+	names := m.Assets(policy)
+	sort.Slice(names, func(i, j int) bool {
+		return bytes.Compare(names[i], names[j]) < 0
+	})
+	return names
+}

--- a/readme.md
+++ b/readme.md
@@ -110,13 +110,17 @@ a := apollo.New(bfc)
 // Legacy largest-first behavior
 a = a.SetCoinSelector(&apollo.LargestFirstSelector{})
 
+// CIP-0002 Random-Improve, or Cardano Wallet-style fallback to Largest-First
+a = a.SetCoinSelector(apollo.NewRandomImproveSelector())
+a = a.SetCoinSelector(apollo.NewRandomImproveThenLargestFirstSelector())
+
 // MACS without dust sweeping, or with custom limits
 a = a.SetCoinSelector(&apollo.MACSSelector{})
 a = a.SetCoinSelector(&apollo.MACSSelector{DustThreshold: 2_000_000, MaxDustInputs: 4})
 ```
 
 Benchmarks live in `coinselection_bench_test.go`
-(`go test -bench BenchmarkCoinSelection`), and the design notes with full
+(`go test -bench BenchmarkCoinSelection`), and the MACS design notes with full
 results are in `docs/design/2026-06-11-macs-coin-selection-design.md`.
 
 If you have any questions or requests feel free to drop into this discord and ask :) https://discord.gg/MH4CmJcg49


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds CIP-0002 Random-Improve coin selection with deterministic randomness, plus an optional fallback that tries Random-Improve and then Largest-First. Improves UTxO selection quality while keeping builds reproducible.

- **New Features**
  - Added `RandomImproveSelector` that covers the target, then improves toward 2× the target using a deterministic shuffle.
  - Added `RandomImproveThenLargestFirstSelector` that falls back to `LargestFirstSelector` only when Random-Improve can’t cover; benches/tests updated and README shows usage.

- **Bug Fixes**
  - Standardized the “insufficient UTxOs” error across selectors for reliable fallback handling.
  - Fallback runs only on insufficient-coverage errors, not on validation or overflow errors; tests added to pin behavior.

<sup>Written for commit 8f0c4911df8526ac8e8728fd38dad6ae1f48d9fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/salvionied-apollo/pull/10?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

